### PR TITLE
removed reference to ipfixcol.png in rpm target

### DIFF
--- a/base/Makefile.am
+++ b/base/Makefile.am
@@ -11,7 +11,7 @@ SUBDIRS +=  documentation/man \
 	    documentation/doxygen
 endif
 
-EXTRA_DIST = README.md ipfixcol.png
+EXTRA_DIST = README.md
 
 .PHONY: doc
 doc: 


### PR DESCRIPTION
Seems like commit 3adf09cdf87977937b0bfb4e8efa01d7a4b17001 removed ipfixcol.png. It's still referenced in base/Makefile and causes `make rpm` to fail
