### PR TITLE
bumped to libfastbit-1.4.0pre13

### DIFF
--- a/plugins/storage/fastbit/ipfixcol-fastbit-output.spec.in
+++ b/plugins/storage/fastbit/ipfixcol-fastbit-output.spec.in
@@ -11,8 +11,8 @@ Packager: @USERNAME@ <@USERMAIL@>
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}
 
 BuildRequires: gcc make doxygen
-Requires: fastbit-liberouter, libfastbit = 1.4.0pre10
-BuildRequires: fastbit-liberouter-devel, libfastbit = 1.4.0pre10, ipfixcol-devel >= 0.7.1
+Requires: fastbit-liberouter, libfastbit = 1.4.0pre13
+BuildRequires: fastbit-liberouter-devel, libfastbit = 1.4.0pre13, ipfixcol-devel >= 0.7.1
 Requires: ipfixcol >= 0.7.1
 
 %description


### PR DESCRIPTION
CESNET's libfastbit is currently on 1.4.0pre13, ipfixcol's fastbit plugin requires 1.4.0pre10. The patch bumps the version.
