### PR TITLE
Fixed invalid element and enterprise ID translations in fields_get_field...

### DIFF
--- a/base/src/ipfix_message.c
+++ b/base/src/ipfix_message.c
@@ -394,8 +394,8 @@ struct ipfix_template_row *fields_get_field(uint8_t *fields, int cnt, uint32_t e
 		uint8_t has_ren = 0;
 		
 		/* Get field ID and enterprise number */
-		if (row->id >> 15) {
-			rid = row->id && 0x7FFF;
+		if (rid >> 15) {
+			rid = rid && 0x7FFF;
 			++row;
 			ren = (netw) ? ntohl(*((uint32_t *) row)) : *((uint32_t *) row);
 			has_ren = 1;


### PR DESCRIPTION
... (ipfix_message.c)

Fixed an issue, introduced in 48231d71ad9ce5bec92e67993521fd23179f7d67, that caused the lookup of enterprise-specific fields within a template to always fail:

In the case where `fields_get_field` is called with `netw = true`, the element ID to look for is converted to network byte order (line 384), while the element IDs in the template records are converted to host byte order (line 409). As such, the element IDs will never match.
