### PR TITLE
Bug fixes for fields_get_field (base/src/ipfix_message.c)

### DIFF
--- a/base/src/ipfix_message.c
+++ b/base/src/ipfix_message.c
@@ -391,19 +391,17 @@ struct ipfix_template_row *fields_get_field(uint8_t *fields, int cnt, uint32_t e
 		uint16_t rid = (netw) ? ntohs(row->id) : row->id;
 		uint16_t len = (netw) ? ntohs(row->length) : row->length;
 		uint32_t ren = 0;
-		uint8_t has_ren = 0;
 		
 		/* Get field ID and enterprise number */
 		if (rid >> 15) {
 			rid = rid & 0x7FFF;
 			++row;
 			ren = (netw) ? ntohl(*((uint32_t *) row)) : *((uint32_t *) row);
-			has_ren = 1;
 		}
 		
 		/* Check informations */
 		if (rid == id && ren == enterprise) {
-			if (has_ren) {
+			if (ren != 0) {
 				--row;
 			}
 			return row;

--- a/base/src/ipfix_message.c
+++ b/base/src/ipfix_message.c
@@ -395,7 +395,7 @@ struct ipfix_template_row *fields_get_field(uint8_t *fields, int cnt, uint32_t e
 		
 		/* Get field ID and enterprise number */
 		if (rid >> 15) {
-			rid = rid && 0x7FFF;
+			rid = rid & 0x7FFF;
 			++row;
 			ren = (netw) ? ntohl(*((uint32_t *) row)) : *((uint32_t *) row);
 			has_ren = 1;


### PR DESCRIPTION
This pull request features two fixes:

* ed1d686: due to a mistake in the number of ampersands, the row's element ID was determined as a comparison, rather than a bitwise AND. As such, the element IDs of enterprise-specific fields was always '1'.
* da469b0: we can use the fact that enterprise IDs (PENs) are non-zero for enterprise-specific fields to get rid of the ```has_ren``` variable, which simplifies the code.