### PR TITLE
Bunch of buffer overflow vulnerability fixes

### DIFF
--- a/base/headers/ipfixcol/utils.h
+++ b/base/headers/ipfixcol/utils.h
@@ -44,6 +44,7 @@
 
 API char **utils_files_from_path(char *path);
 API char  *utils_dir_from_path(char *path);
+API char  *strncpy_safe (char *destination, const char *source, size_t num);
 
 #endif	/* UTILS_H */
 

--- a/base/src/config.c
+++ b/base/src/config.c
@@ -333,16 +333,16 @@ struct plugin_xml_conf_list* get_storage_plugins (xmlNodePtr collector_node, xml
 										strtol((char*) odid, &odidptr, 10);
 										if (*odidptr == '\0') {
 											aux_plugin->config.observation_domain_id = (char*) malloc (sizeof(char) * (xmlStrlen (odid) + 1));
-											strncpy (aux_plugin->config.observation_domain_id, (char*) odid, xmlStrlen (odid) + 1);
+											strncpy_safe(aux_plugin->config.observation_domain_id, (char*) odid, xmlStrlen (odid) + 1);
 										} else {
 											MSG_WARNING(msg_module, "observationDomainId element '%s' not valid. Ignoring...", (char*) odid);
 										}
 									}
 									aux_plugin->config.file = (char*) malloc (sizeof(char) * (xmlStrlen (plugin_file) + 1));
-									strncpy (aux_plugin->config.file, (char*) plugin_file, xmlStrlen (plugin_file) + 1);
+									strncpy_safe(aux_plugin->config.file, (char*) plugin_file, xmlStrlen (plugin_file) + 1);
 									/* copy thread name to prepared string */
 									if (thread_name != NULL) {
-										strncpy (aux_plugin->config.name, (char*) thread_name, 16);
+										strncpy_safe(aux_plugin->config.name, (char*) thread_name, 16);
 									}
 									aux_plugin->config.xmldata = xmlNewDoc (BAD_CAST "1.0");
 									xmlDocSetRootElement (aux_plugin->config.xmldata, xmlCopyNode (node_filewriter, 1));
@@ -513,7 +513,7 @@ struct plugin_xml_conf_list* get_input_plugins (xmlNodePtr collector_node, char 
 				/* find the processName of specified inputPlugin in internalcfg.xml */
 				while (children3) {
 					if (!xmlStrncmp (children3->name, BAD_CAST "processName", strlen ("processName") + 1)) {
-						strncpy(retval->config.name, (char*) children3->children->content, 16);
+						strncpy_safe(retval->config.name, (char*) children3->children->content, 16);
 					}
 					children3 = children3->next;
 				}
@@ -521,7 +521,7 @@ struct plugin_xml_conf_list* get_input_plugins (xmlNodePtr collector_node, char 
 				while (children2) {
 					if (!xmlStrncmp (children2->name, BAD_CAST "file", strlen ("file") + 1)) {
 						retval->config.file = (char*) malloc (sizeof(char) * (strlen ((char*) children2->children->content) + 1));
-						strncpy (retval->config.file, (char*) children2->children->content, strlen ((char*) children2->children->content) + 1);
+						strncpy_safe(retval->config.file, (char*) children2->children->content, strlen ((char*) children2->children->content) + 1);
 						goto found_input_plugin_file;
 					}
 					children2 = children2->next;
@@ -682,10 +682,10 @@ struct plugin_xml_conf_list* get_intermediate_plugins(xmlDocPtr config, char *in
 
 		aux_plugin->config.file = (char *) plugin_file;
 		if (thread_name) {
-			strncpy(aux_plugin->config.name, (char*) thread_name, 16);
+			strncpy_safe(aux_plugin->config.name, (char*) thread_name, 16);
 			xmlFree(thread_name);
 		} else {
-			strncpy(aux_plugin->config.name, (char *) node->name, 16);
+			strncpy_safe(aux_plugin->config.name, (char *) node->name, 16);
 		}
 
 		aux_plugin->config.xmldata = xmldata;

--- a/base/src/input/sctp/convert.c
+++ b/base/src/input/sctp/convert.c
@@ -469,7 +469,7 @@ int insert_timestamp_data(struct ipfix_set_header *dataSet, uint64_t time_header
 void convert_packet(char **packet, ssize_t *len, char *input_info)
 {
 	struct ipfix_header *header = (struct ipfix_header *) *packet;
-	int numOfFlowSamples = 0;
+	uint16_t numOfFlowSamples = 0;
 	info_list = (struct input_info_list *) input_info;
 	switch (htons(header->version)) {
 		/* Netflow v9 packet */

--- a/base/src/input/tcp/convert.c
+++ b/base/src/input/tcp/convert.c
@@ -469,7 +469,7 @@ int insert_timestamp_data(struct ipfix_set_header *dataSet, uint64_t time_header
 void convert_packet(char **packet, ssize_t *len, char *input_info)
 {
 	struct ipfix_header *header = (struct ipfix_header *) *packet;
-	int numOfFlowSamples = 0;
+	uint16_t numOfFlowSamples = 0;
 	info_list = (struct input_info_list *) input_info;
 	switch (htons(header->version)) {
 		/* Netflow v9 packet */

--- a/base/src/input/tcp/tcp_input.c
+++ b/base/src/input/tcp/tcp_input.c
@@ -451,7 +451,7 @@ int input_init(char *params, void **config)
 					    retval = 1;
 					    goto out;
 					}
-					strncpy(tmp_val, (char *)cur_node->children->content, tmp_val_len);
+					strncpy_safe(tmp_val, (char *)cur_node->children->content, tmp_val_len);
 					
 					if (xmlStrEqual(cur_node->name, BAD_CAST "localCAfile")) {
 						/* location of the CA certificate */
@@ -491,7 +491,7 @@ int input_init(char *params, void **config)
                 retval = 1;
                 goto out;
             }
-            strncpy(tmp_val, (char *)cur_node->children->content, tmp_val_len);
+            strncpy_safe(tmp_val, (char *)cur_node->children->content, tmp_val_len);
 
             if (xmlStrEqual(cur_node->name, BAD_CAST "localPort")) { /* set local port */
                 port = tmp_val;

--- a/base/src/input/tcp/tcp_input.c
+++ b/base/src/input/tcp/tcp_input.c
@@ -444,13 +444,14 @@ int input_init(char *params, void **config)
 			/* TLS configuration options */
 	    	for (cur_node = cur_node->xmlChildrenNode; cur_node; cur_node = cur_node->next) {
         		if (cur_node->type == XML_ELEMENT_NODE && cur_node->children != NULL) {
-					char *tmp_val = malloc(sizeof(char)*strlen((char *)cur_node->children->content)+1);
+					int tmp_val_len = strlen((char *) cur_node->children->content) + 1;
+					char *tmp_val = malloc(sizeof(char) * tmp_val_len);
 					if (!tmp_val) {
 						MSG_ERROR(msg_module, "Cannot allocate memory: %s", strerror(errno));
 					    retval = 1;
 					    goto out;
 					}
-					strcpy(tmp_val, (char *)cur_node->children->content);
+					strncpy(tmp_val, (char *)cur_node->children->content, tmp_val_len);
 					
 					if (xmlStrEqual(cur_node->name, BAD_CAST "localCAfile")) {
 						/* location of the CA certificate */
@@ -482,14 +483,15 @@ int input_init(char *params, void **config)
 #endif
         if (cur_node->type == XML_ELEMENT_NODE && cur_node->children != NULL) {
             /* copy value to memory - don't forget the terminating zero */
-            char *tmp_val = malloc(sizeof(char)*strlen((char *)cur_node->children->content)+1);
+            int tmp_val_len = strlen((char *) cur_node->children->content) + 1;
+            char *tmp_val = malloc(sizeof(char) * tmp_val_len);
             /* this is not a preferred cast, but we really want to use plain chars here */
             if (tmp_val == NULL) {
             	MSG_ERROR(msg_module, "Cannot allocate memory: %s", strerror(errno));
                 retval = 1;
                 goto out;
             }
-            strcpy(tmp_val, (char *)cur_node->children->content);
+            strncpy(tmp_val, (char *)cur_node->children->content, tmp_val_len);
 
             if (xmlStrEqual(cur_node->name, BAD_CAST "localPort")) { /* set local port */
                 port = tmp_val;

--- a/base/src/input/udp/convert.c
+++ b/base/src/input/udp/convert.c
@@ -469,7 +469,7 @@ int insert_timestamp_data(struct ipfix_set_header *dataSet, uint64_t time_header
 void convert_packet(char **packet, ssize_t *len, char *input_info)
 {
 	struct ipfix_header *header = (struct ipfix_header *) *packet;
-	int numOfFlowSamples = 0;
+	uint16_t numOfFlowSamples = 0;
 	info_list = (struct input_info_list *) input_info;
 	switch (htons(header->version)) {
 		/* Netflow v9 packet */

--- a/base/src/input/udp/udp_input.c
+++ b/base/src/input/udp/udp_input.c
@@ -158,9 +158,10 @@ int input_init(char *params, void **config)
 	for (cur_node = root_element->children; cur_node; cur_node = cur_node->next) {
 		if (cur_node->type == XML_ELEMENT_NODE && cur_node->children != NULL) {
 			/* copy value to memory - don't forget the terminating zero */
-			char *tmp_val = malloc(sizeof(char)*strlen((char *)cur_node->children->content)+1);
+			int tmp_val_len = strlen((char *) cur_node->children->content) + 1;
+			char *tmp_val = malloc(sizeof(char) * tmp_val_len);
 			/* this is not a preferred cast, but we really want to use plain chars here */
-			strcpy(tmp_val, (char *)cur_node->children->content);
+			strncpy(tmp_val, (char *)cur_node->children->content, tmp_val_len);
 			if (tmp_val == NULL) {
 				MSG_ERROR(msg_module, "Cannot allocate memory: %s", strerror(errno));
 				retval = 1;

--- a/base/src/input/udp/udp_input.c
+++ b/base/src/input/udp/udp_input.c
@@ -161,7 +161,7 @@ int input_init(char *params, void **config)
 			int tmp_val_len = strlen((char *) cur_node->children->content) + 1;
 			char *tmp_val = malloc(sizeof(char) * tmp_val_len);
 			/* this is not a preferred cast, but we really want to use plain chars here */
-			strncpy(tmp_val, (char *)cur_node->children->content, tmp_val_len);
+			strncpy_safe(tmp_val, (char *)cur_node->children->content, tmp_val_len);
 			if (tmp_val == NULL) {
 				MSG_ERROR(msg_module, "Cannot allocate memory: %s", strerror(errno));
 				retval = 1;

--- a/base/src/intermediate/anonymization/Crypto-PAn/panonymizer.c
+++ b/base/src/intermediate/anonymization/Crypto-PAn/panonymizer.c
@@ -111,7 +111,7 @@ uint32_t len = strlen(s);
 
 	if ( strlen(s) == 32 ) {
 		// Key is a string
-		strncpy(key, s, 32);
+		strncpy_safe(key, s, 32);
 		return 1;
 	}
 

--- a/base/src/intermediate/anonymization/Crypto-PAn/rijndael.c
+++ b/base/src/intermediate/anonymization/Crypto-PAn/rijndael.c
@@ -1363,7 +1363,7 @@ int Rijndael_blockDecrypt(const uint8_t *input, int inputLen, uint8_t *outBuffer
 
 int Rijndael_padDecrypt(const uint8_t *input, int inputOctets, uint8_t *outBuffer)
 {
-	int i, numBlocks, padLen;
+	uint16_t i, numBlocks, padLen;
 	uint8_t block[16];
 	uint32_t iv[4];
 

--- a/base/src/intermediate/anonymization/anonymization_ip.c
+++ b/base/src/intermediate/anonymization/anonymization_ip.c
@@ -207,14 +207,15 @@ int intermediate_init(char *params, void *ip_config, uint32_t ip_id, struct ipfi
 
         if (cur_node->type == XML_ELEMENT_NODE && cur_node->children != NULL) {
             /* copy value to memory - don't forget the terminating zero */
-            char *tmp_val = malloc(sizeof(char)*strlen((char *)cur_node->children->content)+1);
+            int tmp_val_len = strlen((char *) cur_node->children->content) + 1;
+            char *tmp_val = malloc(sizeof(char) * tmp_val_len);
             /* this is not a preferred cast, but we really want to use plain chars here */
             if (tmp_val == NULL) {
             	MSG_ERROR(msg_module, "Cannot allocate memory: %s", strerror(errno));
                 retval = 1;
                 goto out;
             }
-            strcpy(tmp_val, (char *)cur_node->children->content);
+            strncpy(tmp_val, (char *)cur_node->children->content, tmp_val_len);
 
             if (xmlStrEqual(cur_node->name, BAD_CAST "type")) { /* anonymization type */
                 if (!strcmp(tmp_val, "truncation")) {

--- a/base/src/intermediate/anonymization/anonymization_ip.c
+++ b/base/src/intermediate/anonymization/anonymization_ip.c
@@ -215,7 +215,7 @@ int intermediate_init(char *params, void *ip_config, uint32_t ip_id, struct ipfi
                 retval = 1;
                 goto out;
             }
-            strncpy(tmp_val, (char *)cur_node->children->content, tmp_val_len);
+            strncpy_safe(tmp_val, (char *)cur_node->children->content, tmp_val_len);
 
             if (xmlStrEqual(cur_node->name, BAD_CAST "type")) { /* anonymization type */
                 if (!strcmp(tmp_val, "truncation")) {

--- a/base/src/intermediate/hooks/hooks.c
+++ b/base/src/intermediate/hooks/hooks.c
@@ -201,7 +201,7 @@ int intermediate_init(char *params, void *ip_config, uint32_t ip_id, struct ipfi
 			len = strlen((char *) aux_char);
 			
 			aux_op->operation = calloc(1, len + 2);
-			strcpy(aux_op->operation, (char *) aux_char);
+			strncpy(aux_op->operation, (char *) aux_char, len);
 			
 			/* add & to the end (if not present) */
 			if (aux_op->operation[len - 1] != '&') {

--- a/base/src/intermediate/hooks/hooks.c
+++ b/base/src/intermediate/hooks/hooks.c
@@ -201,7 +201,7 @@ int intermediate_init(char *params, void *ip_config, uint32_t ip_id, struct ipfi
 			len = strlen((char *) aux_char);
 			
 			aux_op->operation = calloc(1, len + 2);
-			strncpy(aux_op->operation, (char *) aux_char, len);
+			strncpy_safe(aux_op->operation, (char *) aux_char, len);
 			
 			/* add & to the end (if not present) */
 			if (aux_op->operation[len - 1] != '&') {

--- a/base/src/output_manager.c
+++ b/base/src/output_manager.c
@@ -149,7 +149,7 @@ static void *output_manager_plugin_thread(void* config)
 	prctl(PR_SET_NAME, "ipfixcol OM", 0, 0, 0);      /* output managers' manager */
 
 
-    /* loop will break upon receiving NULL from buffer */
+	/* loop will break upon receiving NULL from buffer */
 	while (1) {
 		/* get next data */
 		index = -1;
@@ -177,10 +177,10 @@ static void *output_manager_plugin_thread(void* config)
 				continue;
 			}
 
-		    /* add config to data_mngmts structure */
-	    	output_manager_insert(conf, data_config);
+			/* add config to data_mngmts structure */
+			output_manager_insert(conf, data_config);
 
-	        MSG_NOTICE(msg_module, "[%u] Created new Data manager", msg->input_info->odid);
+			MSG_NOTICE(msg_module, "[%u] Created new Data manager", msg->input_info->odid);
 		}
 
 		if (msg->source_status == SOURCE_STATUS_NEW) {
@@ -325,7 +325,10 @@ static void statistics_print_cpu(struct stat_conf *conf)
 		}
 		
 		/* read thread info */
-		if (fscanf(stat, "%d (%[^)]) %c %*d %*d %*d %*d %*d %*u %*u %*u %*u %*u %lu %lu", &tid, thread_name, &state, &utime, &systime) == EOF) {
+		uint8_t format_str_len = 62 + sizeof(MAX_DIR_LEN) + 1; // 62 is size of the raw format string, without MAX_DIR_LEN; +1 is null-terminating char
+		char format_str[format_str_len];
+		snprintf(format_str, format_str_len, "%%d (%%%d[^)]) %%c %%*d %%*d %%*d %%*d %%*d %%*u %%*u %%*u %%*u %%*u %%lu %%lu", MAX_DIR_LEN);
+		if (fscanf(stat, format_str, &tid, thread_name, &state, &utime, &systime) == EOF) {
 			MSG_ERROR(stat_module, "Error while reading %s: %s", stat_path, strerror(errno));
 		}
 		fclose(stat);

--- a/base/src/storage/ipfix/ipfix_file.c
+++ b/base/src/storage/ipfix/ipfix_file.c
@@ -217,7 +217,7 @@ int storage_init(char *params, void **config)
 	memset(conf->file, 0, path_len);
 
 	/* copy file path, skip "file:" at the beginning of the URI */
-	strncpy(conf->file, (char *) conf->xml_file + 5, path_len);
+	strncpy_safe(conf->file, (char *) conf->xml_file + 5, path_len);
 
 	/* add timestamp at the end of the file name */
 	memset(&tm, 0, sizeof(tm));

--- a/base/src/storage/ipfix/ipfix_file.c
+++ b/base/src/storage/ipfix/ipfix_file.c
@@ -203,20 +203,21 @@ int storage_init(char *params, void **config)
 	/* we only support local files */
 	if (strncmp((char *) conf->xml_file, "file:", 5)) {
 		MSG_ERROR(msg_module, "Element \"file\": invalid URI - "
-		                        "only allowed scheme is \"file:\"");
+								"only allowed scheme is \"file:\"");
 		goto err_init;
 	}
 
 	/* output file path + timestamp */
-	conf->file = (char *) malloc(strlen((char *) conf->xml_file)+13);
+	uint16_t path_len = strlen((char *) conf->xml_file) + 13;
+	conf->file = (char *) malloc(path_len);
 	if (conf->file == NULL) {
 		MSG_ERROR(msg_module, "Not enough memory (%s:%d)", __FILE__, __LINE__);
 		goto err_init;
 	}
-	memset(conf->file, 0, strlen((char *) conf->xml_file)+13);
+	memset(conf->file, 0, path_len);
 
 	/* copy file path, skip "file:" at the beginning of the URI */
-	strcpy(conf->file, (char *) conf->xml_file + 5);
+	strncpy(conf->file, (char *) conf->xml_file + 5, path_len);
 
 	/* add timestamp at the end of the file name */
 	memset(&tm, 0, sizeof(tm));

--- a/base/src/utils/utils.c
+++ b/base/src/utils/utils.c
@@ -281,3 +281,14 @@ char *utils_dir_from_path(char *path)
 	
 	return dir;
 }
+
+/**
+ * \brief Version of strncpy that ensures null-termination.
+ */
+char *strncpy_safe (char *destination, const char *source, size_t num)
+{
+    strncpy(destination, source, num);
+
+    // Ensure null-termination
+    destination[num - 1] = '\0';
+}

--- a/base/src/utils/utils.c
+++ b/base/src/utils/utils.c
@@ -87,7 +87,7 @@ static int regexp_asterisk(char *regexp, char *string)
 		return -1;
 	}
 
-	strcpy(aux_regexp, regexp);
+	strncpy(aux_regexp, regexp, strlen(regexp) + 1);
 	
 	int pos = 1; /* we assume that asterisk is in the middle of the string */
 	if (aux_regexp[0] == asterisk) {

--- a/base/src/utils/utils.c
+++ b/base/src/utils/utils.c
@@ -87,7 +87,7 @@ static int regexp_asterisk(char *regexp, char *string)
 		return -1;
 	}
 
-	strncpy(aux_regexp, regexp, strlen(regexp) + 1);
+	strncpy_safe(aux_regexp, regexp, strlen(regexp) + 1);
 	
 	int pos = 1; /* we assume that asterisk is in the middle of the string */
 	if (aux_regexp[0] == asterisk) {


### PR DESCRIPTION
Several vulnerabilities have been fixed, mostly related to (potential) buffer overflows. To avoid repeating error-prone code for fixing every instance of `str(n)cpy`, I've implemented util-function `strncpy_safe` and replaced every instance of `str(n)cpy` with it.