### PR TITLE
Refactoring of preprocessor_compute_crc

### DIFF
--- a/base/src/preprocessor.c
+++ b/base/src/preprocessor.c
@@ -93,7 +93,7 @@ struct odid_info *odid_info_add(uint32_t odid)
 
 	aux_info = calloc(1, sizeof(struct odid_info));
 	if (!aux_info) {
-		MSG_ERROR(msg_module, "Not enought memory (%s:%d)", __FILE__, __LINE__);
+		MSG_ERROR(msg_module, "Not enough memory (%s:%d)", __FILE__, __LINE__);
 		return NULL;
 	}
 	aux_info->odid = odid;
@@ -553,7 +553,7 @@ void preprocessor_parse_msg (void* packet, int len, struct input_info* input_inf
 		*seqn += msg->data_records_count;
 	}
 
-    /* Send data to the first intermediate plugin */
+	/* Send data to the first intermediate plugin */
 	if (rbuffer_write(preprocessor_out_queue, msg, 1) != 0) {
 		MSG_WARNING(msg_module, "[%u] Unable to write into Data manager's input queue, skipping data.", input_info->odid);
 		message_free(msg);

--- a/base/src/preprocessor.c
+++ b/base/src/preprocessor.c
@@ -250,20 +250,22 @@ uint32_t preprocessor_compute_crc(struct input_info *input_info)
 	
 	struct input_info_network *input = (struct input_info_network *) input_info;
 
-	char buff[35];
+	char buff[INET6_ADDRSTRLEN + 5 + 1]; // 5: port; 1: null
 	uint8_t size;
 	if (input->l3_proto == 6) { /* IPv6 */
-		memcpy(buff, &(input->src_addr.ipv6.__in6_u.__u6_addr8), 32);
-		size = 34;
+		size = INET6_ADDRSTRLEN;
+		inet_ntop(AF_INET6, &(input->src_addr.ipv6.s6_addr), buff, size);
 	} else { /* IPv4 */
-		memcpy(buff, &(input->src_addr.ipv4.s_addr), 8);
-		size = 10;
+		size = INET_ADDRSTRLEN;
+		inet_ntop(AF_INET, &(input->src_addr.ipv4.s_addr), buff, size);
 	}
-	memcpy(buff + size - 2, &(input->src_port), 2);
-	buff[size] = '\0';
+
+	uint8_t ip_addr_len = strlen(buff);
+	snprintf(buff + ip_addr_len, 5 + 1, "%u", input->src_port);
 
 	return crc32(buff, size);
 }
+
 /**
  * \brief Fill in udp_info structure when managing UDP input
  *

--- a/base/src/preprocessor.c
+++ b/base/src/preprocessor.c
@@ -251,19 +251,16 @@ uint32_t preprocessor_compute_crc(struct input_info *input_info)
 	struct input_info_network *input = (struct input_info_network *) input_info;
 
 	char buff[INET6_ADDRSTRLEN + 5 + 1]; // 5: port; 1: null
-	uint8_t size;
 	if (input->l3_proto == 6) { /* IPv6 */
-		size = INET6_ADDRSTRLEN;
-		inet_ntop(AF_INET6, &(input->src_addr.ipv6.s6_addr), buff, size);
+		inet_ntop(AF_INET6, &(input->src_addr.ipv6.s6_addr), buff, INET6_ADDRSTRLEN);
 	} else { /* IPv4 */
-		size = INET_ADDRSTRLEN;
-		inet_ntop(AF_INET, &(input->src_addr.ipv4.s_addr), buff, size);
+		inet_ntop(AF_INET, &(input->src_addr.ipv4.s_addr), buff, INET_ADDRSTRLEN);
 	}
 
 	uint8_t ip_addr_len = strlen(buff);
 	snprintf(buff + ip_addr_len, 5 + 1, "%u", input->src_port);
 
-	return crc32(buff, size);
+	return crc32(buff, strlen(buff));
 }
 
 /**

--- a/base/src/storage/forwarding/forwarding.c
+++ b/base/src/storage/forwarding/forwarding.c
@@ -261,7 +261,7 @@ struct forwarding_template_record *forwarding_add_record(forwarding *conf, struc
 		conf->records_max += 32;
 		conf->records = realloc(conf->records, conf->records_max * sizeof(struct forwarding_template_record *));
 		if (conf->records == NULL) {
-			MSG_ERROR(msg_module, "Not enought memory (%s:%d)", __FILE__, __LINE__);
+			MSG_ERROR(msg_module, "Not enough memory (%s:%d)", __FILE__, __LINE__);
 			return NULL;
 		}
 		/* Initialize new pointers */
@@ -275,7 +275,7 @@ struct forwarding_template_record *forwarding_add_record(forwarding *conf, struc
 		if (conf->records[i] == NULL) {
 			conf->records[i] = calloc(1, sizeof(struct forwarding_template_record));
 			if (conf->records[i] == NULL) {
-				MSG_ERROR(msg_module, "Not enought memory (%s:%d)", __FILE__, __LINE__);
+				MSG_ERROR(msg_module, "Not enough memory (%s:%d)", __FILE__, __LINE__);
 				return NULL;
 			}
 			conf->records[i]->record = record;
@@ -698,7 +698,7 @@ int forwarding_record_sent(forwarding *conf, struct ipfix_template_record *rec, 
 	/* Store new record */
 	struct ipfix_template_record *stored = calloc(1, len);
 	if (!stored) {
-		MSG_ERROR(msg_module, "Not enought memory (%s:%d)", __FILE__, __LINE__);
+		MSG_ERROR(msg_module, "Not enough memory (%s:%d)", __FILE__, __LINE__);
 		return 0;
 	}
 
@@ -906,7 +906,7 @@ int store_packet(void *config, const struct ipfix_message *ipfix_msg,
 
 	uint8_t *new_msg = malloc(65535);
 	if (!new_msg) {
-		MSG_ERROR(msg_module, "Not enought memory (%s:%d)", __FILE__, __LINE__);
+		MSG_ERROR(msg_module, "Not enough memory (%s:%d)", __FILE__, __LINE__);
 		return 1;
 	}
 


### PR DESCRIPTION
The old version of `preprocessor_compute_crc` was copying more data than it should (using `memcpy`) and was rather error-prone. In addition, the produced output (`buff`) was just empty. The new version of `preprocessor_compute_crc` is much easier to read. Please let me know whether this matches your vision with regard to this function and provide me with feedback, if needed.