### PR TITLE
fbitdump: fix for -m segfault

### DIFF
--- a/tools/fbitdump/src/Configuration.cpp
+++ b/tools/fbitdump/src/Configuration.cpp
@@ -218,7 +218,7 @@ int Configuration::init(int argc, char *argv[]) throw (std::invalid_argument)
 		}
 		case 'm':
 			this->optm = true;
-			if (optarg == std::string("")) {
+			if (optarg == NULL || optarg == std::string("")) {
 				optionm = "%ts"; /* default is timestamp column */
 			} else {
 				optionm = optarg;


### PR DESCRIPTION
During one of the later merging iterations, an error has been introduced that could cause a segfault when fbitdump was called with parameter `-m`.