### PR TITLE
Invalid handling of unspecified IEs

### DIFF
--- a/plugins/storage/fastbit/fastbit_element.cpp
+++ b/plugins/storage/fastbit/fastbit_element.cpp
@@ -101,6 +101,7 @@ int load_types_from_xml(struct fastbit_config *conf) {
 enum store_type get_type_from_xml(struct fastbit_config *conf, unsigned int en, unsigned int id) {
 	// Check whether a type has been determined for the specified element
 	if ((*conf->elements_types).count(en) == 0 || (*conf->elements_types)[en].count(id) == 0) {
+		MSG_WARNING(MSG_MODULE,"No specification for e%ui%u found in %s", en, id, ipfix_elements);
 		return UNKNOWN;
 	}
 

--- a/plugins/storage/fastbit/fastbit_element.cpp
+++ b/plugins/storage/fastbit/fastbit_element.cpp
@@ -60,15 +60,12 @@ int load_types_from_xml(struct fastbit_config *conf) {
 	if (!result) {
 		MSG_ERROR(MSG_MODULE, "%s parsed with errors!", ipfix_elements);
 		MSG_ERROR(MSG_MODULE, "Error description: %s", result.description());
-
 		return -1;
 	}
 
 	pugi::xpath_node_set elements = doc.select_nodes("/ipfix-elements/element");
 	for (pugi::xpath_node_set::const_iterator it = elements.begin(); it != elements.end(); ++it)
 	{
-		//pugi::xpath_node node = *it;
-
 		str_value = it->node().child_value("enterprise");
 		en = strtoul(str_value.c_str(),NULL,0);
 		str_value = it->node().child_value("id");
@@ -93,7 +90,7 @@ int load_types_from_xml(struct fastbit_config *conf) {
 		} else {
 			type = UNKNOWN;
 		}
-		//conf->elements_types->insert(std::make_pair(en , std::make_pair(id, type)));
+
 		(*conf->elements_types)[en][id] = type;
 		//std::cout << "el loaded: " << en << ":" << id <<":"<< type << std::endl;
 	}
@@ -102,6 +99,11 @@ int load_types_from_xml(struct fastbit_config *conf) {
 }
 
 enum store_type get_type_from_xml(struct fastbit_config *conf, unsigned int en, unsigned int id) {
+	// Check whether a type has been determined for the specified element
+	if ((*conf->elements_types).count(en) == 0 || (*conf->elements_types)[en].count(id) == 0) {
+		return UNKNOWN;
+	}
+
 	return (*conf->elements_types)[en][id];
 }
 


### PR DESCRIPTION
In case an IE in a template has not been specified in `ipfix-elements.xml`, the function `get_type_from_xml` (fastbit_element.cpp) would return `NULL`. As such, the switch-statement in fastbit_table.cpp (`template_table::parse_template`) would not trigger the `UNKNOWN` or `default` cases, resulting in undefined behavior.