### PR TITLE
Improved IPFIXcol input parameter handling

### DIFF
--- a/base/headers/ipfixcol/utils.h
+++ b/base/headers/ipfixcol/utils.h
@@ -45,6 +45,7 @@
 API char **utils_files_from_path(char *path);
 API char  *utils_dir_from_path(char *path);
 API char  *strncpy_safe (char *destination, const char *source, size_t num);
+API int    strtoi (const char* str, int base);
 
 #endif	/* UTILS_H */
 

--- a/base/src/ipfixcol.c
+++ b/base/src/ipfixcol.c
@@ -256,13 +256,6 @@ int main (int argc, char* argv[])
 		internal_file = INTERNAL_CONFIG_FILE;
 		MSG_NOTICE(msg_module, "Using default internal configuration file: %s", internal_file);
 	}
-
-	/* check IPFIX elements file */
-	if (ipfix_elements == NULL) {
-		/* and use default if not specified */
-		ipfix_elements = DEFAULT_IPFIX_ELEMENTS;
-		MSG_NOTICE(msg_module, "Using default IPFIX IE specification: %s", ipfix_elements);
-	}
 	  
 	/* Initialize configurator */
 	config = config_init(internal_file, config_file);

--- a/base/src/utils/utils.c
+++ b/base/src/utils/utils.c
@@ -43,6 +43,8 @@
 #include <string.h>
 
 #include <dirent.h>
+#include <errno.h>
+#include <limits.h>
 #include <sys/stat.h>
 #include <libgen.h>
 #include <stdio.h>
@@ -177,7 +179,7 @@ char **utils_files_from_path(char *path)
 	}
 
 	int len = offsetof(struct dirent, d_name) + 
-	          pathconf(dirname, _PC_NAME_MAX) + 1;
+			pathconf(dirname, _PC_NAME_MAX) + 1;
 
 	entry = (struct dirent *) malloc(len);
 	if (entry == NULL) {
@@ -294,10 +296,33 @@ char *utils_dir_from_path(char *path)
  */
 char *strncpy_safe (char *destination, const char *source, size_t num)
 {
-    strncpy(destination, source, num);
+	strncpy(destination, source, num);
 
-    // Ensure null-termination
-    destination[num - 1] = '\0';
+	// Ensure null-termination
+	destination[num - 1] = '\0';
 
 	return destination;
+}
+
+/**
+ * \brief Version of strtol with proper error-handling.
+ *
+ * \return Converted integer value of the supplied String, INT_MAX otherwise.
+ */
+int strtoi (const char* str, int base)
+{
+	char *end;
+	errno = 0;
+	const long ret_long = strtol(str, &end, base);
+	int ret_int;
+
+	if (end == str) { // String does not feature a valid number
+		ret_int = INT_MAX;
+	} else if ((ret_long <= INT_MIN || ret_long >= INT_MAX) && errno == ERANGE) { // Number is out of range
+		ret_int = INT_MAX;
+	} else {
+		ret_int = (int) ret_long;
+	}
+
+	return ret_int;
 }


### PR DESCRIPTION
Due to missing error handling functionality for `atoi`, I've implemented an improved version that is based on `strtol` with proper error handling. This avoids many potential errors when trying to start IPFIXcol with invalid parameters.