### PR TITLE
fbitdump stability fixes: handling of -N arguments

### DIFF
--- a/tools/fbitdump/man/fbitdump.dbk
+++ b/tools/fbitdump/man/fbitdump.dbk
@@ -179,7 +179,7 @@
 			</varlistentry>
 			
 			<varlistentry>
-				<term>-N <replaceable class="parameter">level</replaceable></term>
+				<term>-N[<replaceable class="parameter">level</replaceable>]</term>
 				<listitem>
 					<simpara>Set plain level limit for printing plain numbers.</simpara>
 					<simpara>Each plugin has a "plainLevel" value. If <replaceable class="parameter">level</replaceable> in this option is greater than or equal to the plugin's plainLevel, columns formatted

--- a/tools/fbitdump/src/Configuration.cpp
+++ b/tools/fbitdump/src/Configuration.cpp
@@ -279,11 +279,15 @@ int Configuration::init(int argc, char *argv[])
 			break;
 		case 'i': /* create indexes */
 			this->createIndexes = true;
-			indexes = optarg;
+			if (optarg != NULL) {
+				indexes = optarg;
+			}
 			break;
 		case 'd': /* delete indexes */
 			this->deleteIndexes = true;
-			indexes = optarg;
+			if (optarg != NULL) {
+				indexes = optarg;
+			}
 			break;
 		case 'C': /* Configuration file */
 			if (optarg == std::string("")) {
@@ -798,7 +802,7 @@ void Configuration::help() const
 	<< "-v <level>      Set verbosity level" << std::endl
 	<< "-V              Print version and exit" << std::endl
 	<< "-a              Aggregate flow data" << std::endl
-	<< "-A [<expr>]     Aggregation fields, separated by ','. For a list of fields, please check fbitdump(1)" << std::endl
+	<< "-A[<expr>]      Aggregation fields, separated by ','. For a list of fields, please check fbitdump(1)" << std::endl
 //	<< "                or subnet aggregation: srcip4/24, srcip6/64." << std::endl
 	//<< "-b              Aggregate flow records as bidirectional flows." << std::endl
 	//<< "-B              Aggregate flow records as bidirectional flows - Guess direction." << std::endl
@@ -813,8 +817,8 @@ void Configuration::help() const
 	<< "-q              Quiet: Do not print the header and bottom stat lines" << std::endl
 	<< "-e				Extended bottom stats. Print summary of statistics columns" << std::endl
 	//<< "-H Add xstat histogram data to flow file.(default 'no')" << std::endl
-	<< "-i [column1[,column2,...]]	Build indexes for given columns (or all) for specified data" << std::endl
-	<< "-d [column1[,column2,...]]	Delete indexes for given columns (or all) for specified data" << std::endl
+	<< "-i[column1[,column2,...]]	Build indexes for given columns (or all) for specified data" << std::endl
+	<< "-d[column1[,column2,...]]	Delete indexes for given columns (or all) for specified data" << std::endl
 	//<< "-j <file>       Compress/Uncompress file." << std::endl
 	//<< "-z              Compress flows in output file. Used in combination with -w." << std::endl
 	//<< "-l <expr>       Set limit on packets for line and packed output format." << std::endl

--- a/tools/fbitdump/src/Configuration.cpp
+++ b/tools/fbitdump/src/Configuration.cpp
@@ -348,7 +348,7 @@ int Configuration::init(int argc, char *argv[])
 		processMOption(tables, optionM.c_str(), optionr);
 	}
 
-	/* allways process option -m, we need to know whether aggregate or not */
+	/* always process option -m, we need to know whether aggregate or not */
 	if (this->optm) {
 		this->processmOption(optionm);
 	}
@@ -360,6 +360,7 @@ int Configuration::init(int argc, char *argv[])
 	Utils::printStatus( "Loading modules");
 
 	this->loadModules();
+
 	/* read filter */
 	if (optind < argc) {
 		this->filter = argv[optind];
@@ -375,7 +376,6 @@ int Configuration::init(int argc, char *argv[])
 
 		this->filter.assign((std::istreambuf_iterator<char>(t)),
 		std::istreambuf_iterator<char>());
-
 	} else {
 		/* set default filter */
 		this->filter = "1=1";
@@ -811,7 +811,7 @@ void Configuration::help() const
 	<< "-n <number>     Define number of top N. -c option takes precedence over -n" << std::endl
 	<< "-c <number>     Limit number of records to display" << std::endl
 	<< "-D <dns>        Use nameserver <dns> for host lookup. Does not support IPv6 addresses" << std::endl
-	<< "-N <level>      Set plain number printing level. Please check fbitdump(1) for detailed information" << std::endl
+	<< "-N[<level>]     Set plain number printing level. Please check fbitdump(1) for detailed information" << std::endl
 	<< "-s <column>[/<order>]     Generate statistics for <column> any valid record element" << std::endl
 	<< "                and ordered by <order>. Order can be any summarizable column, just as for -m option" << std::endl
 	<< "-q              Quiet: do not print statistics" << std::endl

--- a/tools/fbitdump/src/Configuration.cpp
+++ b/tools/fbitdump/src/Configuration.cpp
@@ -374,7 +374,7 @@ int Configuration::init(int argc, char *argv[])
 		t.seekg(0, std::ios::beg);
 
 		this->filter.assign((std::istreambuf_iterator<char>(t)),
-        std::istreambuf_iterator<char>());
+		std::istreambuf_iterator<char>());
 
 	} else {
 		/* set default filter */
@@ -990,44 +990,44 @@ void Configuration::processMOption(stringVector &tables, const char *optarg, std
 
 void Configuration::processROption(stringVector &tables, const char *optarg)
 {
-    std::string arg = optarg;
+	std::string arg = optarg;
 
-    /* Find separator */
-    size_t pos = arg.find(':');
-    if (pos == arg.npos) {
-        /* Specified only one directory */
+	/* Find separator */
+	size_t pos = arg.find(':');
+	if (pos == arg.npos) {
+		/* Specified only one directory */
 	Utils::sanitizePath(arg);
-        tables.push_back(arg);
-        return;
-    }
+		tables.push_back(arg);
+		return;
+	}
 
-    /* Get left and right path */
-    std::string left = arg.substr(0, pos);
-    std::string right = arg.substr(pos + 1);
+	/* Get left and right path */
+	std::string left = arg.substr(0, pos);
+	std::string right = arg.substr(pos + 1);
 
-    /* Right path is ready and can be sanitized */
-    Utils::sanitizePath(right);
+	/* Right path is ready and can be sanitized */
+	Utils::sanitizePath(right);
 
-    /* Get root directory (== left - depth of right) */
-    uint16_t right_depth = std::count(right.begin(), right.end(), '/');
+	/* Get root directory (== left - depth of right) */
+	uint16_t right_depth = std::count(right.begin(), right.end(), '/');
 
-    std::string root = left;
-    while (right_depth--) {
-	root = root.substr(0, root.find_last_of('/'));
-    }
+	std::string root = left;
+	while (right_depth--) {
+	   root = root.substr(0, root.find_last_of('/'));
+	}
 
-    /* Get first firectory */
-    if (root == left) {
-	root = "./";
-    } else {
-	left = left.substr(root.length() + 1);
-    }
+	/* Get first firectory */
+	if (root == left) {
+	   root = "./";
+	} else {
+	   left = left.substr(root.length() + 1);
+	}
 
-    Utils::sanitizePath(root);
-    Utils::sanitizePath(left);
+	Utils::sanitizePath(root);
+	Utils::sanitizePath(left);
 
-    /* Load dirs */
-    Utils::loadDirsTree(root, left, right, tables);
+	/* Load dirs */
+	Utils::loadDirsTree(root, left, right, tables);
 }
 
 void Configuration::parseAggregateArg(char *arg) throw (std::invalid_argument)
@@ -1041,7 +1041,7 @@ void Configuration::parseAggregateArg(char *arg) throw (std::invalid_argument)
 	if (arg == NULL) return;
 
 	if (!Utils::splitString(arg, this->aggregateColumnsAliases)) {
-		throw std::invalid_argument(std::string("Ivalid input string ") + arg);
+		throw std::invalid_argument(std::string("Invalid input string '") + arg + std::string("'"));
 	}
 }
 
@@ -1075,7 +1075,7 @@ void Configuration::loadOutputFormat()
 	pugi::xpath_node format = this->getXMLConfiguration().select_single_node(("/configuration/output/format[formatName='"+this->format+"']").c_str());
 	/* check what we found */
 	if (format == NULL) {
-		throw std::invalid_argument(std::string("Format '") + this->format + "' is not defined");
+		throw std::invalid_argument(std::string("Format '") + this->format + "' not defined");
 	}
 
 	/* set format string */

--- a/tools/fbitdump/src/Configuration.cpp
+++ b/tools/fbitdump/src/Configuration.cpp
@@ -145,13 +145,21 @@ int Configuration::init(int argc, char *argv[])
 			break;
 		case 'N': /* print plain numbers */
 			if (optarg == NULL || optarg == std::string("")) {
-				this->plainLevel = 1;
-				//throw std::invalid_argument("-N requires a level specification");
+				/* If the value after '-N' (separated by whitespace) is an integer,
+				 * the user has probably used a whitespace mistakenly.
+				 */
+				if (optind < argc && Utils::strtoi(argv[optind], 10) < INT_MAX) {
+					this->plainLevel = Utils::strtoi(argv[optind], 10);
+
+					// Skip to next argument; make sure integer is not parsed as query filter
+					++optind;
+				} else {
+					this->plainLevel = 1;
+				}
 			} else {
-				//this->plainLevel = atoi(optarg);
-				char *endptr = NULL;
-				this->plainLevel = strtol(optarg, &endptr, 10);
-				if (endptr == optarg) {
+				this->plainLevel = Utils::strtoi(argv[optind], 10);
+
+				if (this->plainLevel == INT_MAX) {
 					throw std::invalid_argument("-N requires an integer level specification");
 				}
 			}

--- a/tools/fbitdump/src/Filter.cpp
+++ b/tools/fbitdump/src/Filter.cpp
@@ -122,7 +122,7 @@ void Filter::init(Configuration &conf) throw (std::invalid_argument)
 		/* run parser */
 		if (parser.parse() != 0) {
 			yylex_destroy(this->scaninfo);
-			throw std::invalid_argument(std::string("Error while parsing filter!"));
+			throw std::invalid_argument(std::string("Error while parsing filter (" + input + ")"));
 		}
 
 		yy_flush_buffer(bp, this->scaninfo);

--- a/tools/fbitdump/src/Utils.cpp
+++ b/tools/fbitdump/src/Utils.cpp
@@ -278,6 +278,29 @@ char *strncpy_safe (char *destination, const char *source, size_t num)
     return destination;
 }
 
+/**
+ * \brief Version of strtol with proper error-handling.
+ *
+ * \return Converted integer value of the supplied String, INT_MAX otherwise.
+ */
+int strtoi (const char* str, int base)
+{
+    char *end;
+    errno = 0;
+    const long ret_long = strtol(str, &end, base);
+    int ret_int;
+
+    if (end == str) { // String does not feature a valid number
+        ret_int = INT_MAX;
+    } else if ((ret_long <= INT_MIN || ret_long >= INT_MAX) && errno == ERANGE) { // Number is out of range
+        ret_int = INT_MAX;
+    } else {
+        ret_int = (int) ret_long;
+    }
+
+    return ret_int;
+}
+
 } /* end of namespace utils */
 
 }  /* end of namespace fbitdump */

--- a/tools/fbitdump/src/Utils.h
+++ b/tools/fbitdump/src/Utils.h
@@ -133,6 +133,7 @@ void loadDirRange(std::string &basedir, std::string &firstDir, std::string &last
 	throw (std::invalid_argument);
 
 char *strncpy_safe (char *destination, const char *source, size_t num);
+int strtoi (const char* str, int base);
 
 } /* end of namespace utils */
 

--- a/tools/fbitdump/src/fbitdump.cpp
+++ b/tools/fbitdump/src/fbitdump.cpp
@@ -60,9 +60,6 @@ int main(int argc, char *argv[])
 	/* raise limit for cache size, when there is more memory available */
 	/* default is half of available physical memory */
 	//ibis::fileManager::adjustCacheSize(2048000000);
-
-//	ibis::fileManager::instance().printStatus(std::cout);
-
 	//ibis::gVerbose = 7;
 
 
@@ -70,7 +67,6 @@ int main(int argc, char *argv[])
 
 	/* create configuration to work with */
 	Configuration conf;
-//	Configuration::instance = &conf;
 	std::ofstream pipe;
 
 	/* process configuration and check whether to end the program */
@@ -109,22 +105,22 @@ int main(int argc, char *argv[])
 
 	try {
 		/* create filters */
-		Utils::printStatus( "Creating filters");
+		Utils::printStatus("Creating filters");
 
 		Filter filter(conf);
 		AggregateFilter aggregateFilter(conf);
 		
-		Utils::printStatus( "Initializing printer");
+		Utils::printStatus("Initializing printer");
 		
 		/* initialise printer */
 		Printer print(std::cout, conf);
-		Utils::printStatus( "Initializing tables");
+		Utils::printStatus("Initializing tables");
 
 		/* initialise tables */
 		TableManager tm(conf);
 		/* check whether to delete indexes */
 		if (conf.getDeleteIndexes()) {
-			Utils::printStatus( "Deleting indexes");
+			Utils::printStatus("Deleting indexes");
 
 			IndexManager::deleteIndexes(conf, tm);
 
@@ -141,7 +137,7 @@ int main(int argc, char *argv[])
 
 		/* check whether to build indexes */
 		if (conf.getCreateIndexes()) {
-			Utils::printStatus( "Building indexes");
+			Utils::printStatus("Building indexes");
 
 			IndexManager::createIndexes(conf, tm);
 			if (access (conf.pipe_name.c_str(), F_OK ) == 0 ) {
@@ -157,7 +153,7 @@ int main(int argc, char *argv[])
 
 		/* check whether to print template information */
 		if (conf.getTemplateInfo()) {
-			Utils::printStatus( "Printing templates");
+			Utils::printStatus("Printing templates");
 
 			TemplateInfo::printTemplates(tm, conf);
 		}
@@ -166,7 +162,7 @@ int main(int argc, char *argv[])
 		if (!conf.getDeleteIndexes() && !conf.getCreateIndexes() && !conf.getTemplateInfo()) {
 			/* do the work */
 			if (conf.getAggregate()) {
-				Utils::printStatus( "Aggregating tables");
+				Utils::printStatus("Aggregating tables");
 				tm.aggregate(conf.getAggregateColumns(), conf.getSummaryColumns(), filter);
 				
 				/* Apply post aggregate filter */
@@ -179,12 +175,13 @@ int main(int argc, char *argv[])
 			}
 
 			/* clear line with spaces - removing progressbar if anny */
-			if(isatty(fileno(stdout))) {
+			if (isatty(fileno(stdout))) {
 				std::cout.width(80);
 				std::cout.fill( ' ');
 				std::cout << "\r";
 				std::cout.flush();
 			}
+			
 			/* print tables */
 			print.print(tm);
 		}


### PR DESCRIPTION
The handling of -N arguments by `fbitdump` has turned out to be rather fragile after the recent implementation of optional arguments. The reason for this is that if the (integer) number printing level indicator for -N is written with a white-space separator (e.g., `-N 5`), `5` would be treated as the query filter rather than the number printing level indicator.