### PR TITLE
Panonymizer.c: fixed previous improvement that results in decreased entropy

### DIFF
--- a/base/src/intermediate/anonymization/Crypto-PAn/panonymizer.c
+++ b/base/src/intermediate/anonymization/Crypto-PAn/panonymizer.c
@@ -112,7 +112,11 @@ uint32_t len = strlen(s);
 
 	if ( strlen(s) == 32 ) {
 		// Key is a string
-		strncpy_safe(key, s, 32);
+		/*
+		 * Note: strncpy_safe should NOT be used here, since it always sets the key's last byte to 0,
+		 * resulting in decreased entropy.
+		 */
+		strncpy(key, s, 32);
 		return 1;
 	}
 


### PR DESCRIPTION
We previously replaced all invocations of `strncpy` by `strncpy_safe`, to ensure safe String termination. In this particular case, however, this change results in decreased entropy (the last byte of the key is always zero). We therefore revert this change here.