### PR TITLE
utils/profiles/profiles.cpp: fixed resource leak

### DIFF
--- a/base/src/utils/profiles/profiles.cpp
+++ b/base/src/utils/profiles/profiles.cpp
@@ -74,7 +74,7 @@ int parse_filter(filter_parser_data* pdata)
 	yylex_init(&(pdata->scanner));
 	YY_BUFFER_STATE bp = yy_scan_string(pdata->filter, pdata->scanner);
 	yy_switch_to_buffer(bp, pdata->scanner);
-    
+
 	/* Parse filter */
 	ret = yyparse(pdata);
 	
@@ -251,7 +251,10 @@ Profile *process_profile_xml(const char *filename)
 
 	try {
 		/* Iterate throught all profiles */
-		for (xmlNode *node = root; node; node = node->next) {
+		/* rootProfile must be considered as loop condition, since storage allocated
+		   by process_profile will be leaked otherwise
+		 */
+		for (xmlNode *node = root; node && !rootProfile; node = node->next) {
 			if (node->type != XML_ELEMENT_NODE) {
 				continue;
 			}


### PR DESCRIPTION
Please double-check this fix. The point is that the `for`-loop has to stop iterating once a `rootProfile` has been found.