### PR TITLE
Various configure fixes for several plugins

### DIFF
--- a/plugins/intermediate/geoip/configure.ac
+++ b/plugins/intermediate/geoip/configure.ac
@@ -84,6 +84,12 @@ AM_CONDITIONAL([HAVE_DOC], [test "$enable_doc" != "no"])
 
 ############################ Check for libraries ###############################
 
+### LibXML2 ###
+AC_CHECK_LIB([xml2], [main],
+    [LIBS="`xml2-config --libs` $LIBS"
+    CPPFLAGS="`xml2-config --cflags` $CPPFLAGS"],
+    AC_MSG_ERROR([Libxml2 not found ]))
+
 ######################### Checks for header files ##############################
 AC_CHECK_HEADERS([float.h netinet/in.h stddef.h stdint.h stdlib.h string.h wchar.h])
 

--- a/plugins/intermediate/geoip/geoip.c
+++ b/plugins/intermediate/geoip/geoip.c
@@ -40,7 +40,7 @@
 #include <ipfixcol.h>
 #include <ipfixcol/intermediate.h>
 #include <libxml/parser.h>
-#include <libxml2/libxml/tree.h>
+#include <libxml/tree.h>
 
 #include <GeoIP.h>
 #include <geoip.h>

--- a/plugins/intermediate/profile_stats/configure.ac
+++ b/plugins/intermediate/profile_stats/configure.ac
@@ -91,7 +91,7 @@ AM_CONDITIONAL([HAVE_DOC], [test "$enable_doc" != "no"])
 ### LibXML2 ###
 AC_CHECK_LIB([xml2], [main],
     [LIBS="`xml2-config --libs` $LIBS"
-    CFLAGS="`xml2-config --cflags` $CFLAGS"],
+    CPPFLAGS="`xml2-config --cflags` $CPPFLAGS"],
     AC_MSG_ERROR([Libxml2 not found ]))
 
 ### RRD library ###

--- a/plugins/intermediate/profile_stats/configure.ac
+++ b/plugins/intermediate/profile_stats/configure.ac
@@ -102,7 +102,7 @@ AC_CHECK_HEADERS([float.h netinet/in.h stddef.h stdint.h stdlib.h string.h wchar
 
 # Check whether we can find headers dir in relative path (git repository)
 AS_IF([test -d $srcdir/../../../base/headers], 
-	[CPPFLAGS+="-I$srcdir/../../../base/headers"]
+	[CPPFLAGS+=" -I$srcdir/../../../base/headers"]
 )
 
 AC_CHECK_HEADERS([ipfixcol.h], , AC_MSG_ERROR([ipfixcol.h header missing. Please install ipfixcol-devel package]), [AC_INCLUDES_DEFAULT])

--- a/plugins/intermediate/profiler/configure.ac
+++ b/plugins/intermediate/profiler/configure.ac
@@ -97,7 +97,7 @@ AC_CHECK_HEADERS([float.h netinet/in.h stddef.h stdint.h stdlib.h string.h wchar
 
 # Check whether we can find headers dir in relative path (git repository)
 AS_IF([test -d $srcdir/../../../base/headers], 
-	[CPPFLAGS+="-I$srcdir/../../../base/headers"]
+	[CPPFLAGS+=" -I$srcdir/../../../base/headers"]
 )
 
 AC_CHECK_HEADERS([ipfixcol.h], , AC_MSG_ERROR([ipfixcol.h header missing. Please install ipfixcol-devel package]), [AC_INCLUDES_DEFAULT])

--- a/plugins/intermediate/stats/configure.ac
+++ b/plugins/intermediate/stats/configure.ac
@@ -102,7 +102,7 @@ AC_CHECK_HEADERS([float.h netinet/in.h stddef.h stdint.h stdlib.h string.h wchar
 
 # Check whether we can find headers dir in relative path (git repository)
 AS_IF([test -d $srcdir/../../../base/headers], 
-	[CPPFLAGS+="-I$srcdir/../../../base/headers"]
+    [CPPFLAGS+=" -I$srcdir/../../../base/headers"]
 )
 
 AC_CHECK_HEADERS([ipfixcol.h], , AC_MSG_ERROR([ipfixcol.h header missing. Please install ipfixcol-devel package]), [AC_INCLUDES_DEFAULT])

--- a/plugins/intermediate/uid/configure.ac
+++ b/plugins/intermediate/uid/configure.ac
@@ -84,6 +84,13 @@ AM_CONDITIONAL([HAVE_DOC], [test "$enable_doc" != "no"])
 
 ############################ Check for libraries ###############################
 
+### LibXML2 ###
+AC_CHECK_LIB([xml2], [main],
+    [LIBS="`xml2-config --libs` $LIBS"
+    CPPFLAGS="`xml2-config --cflags` $CPPFLAGS"],
+    AC_MSG_ERROR([Libxml2 not found ]))
+
+
 AC_SEARCH_LIBS([sqlite3_open], [sqlite3],,
 		AC_MSG_ERROR([Required library sqlite3 missing]))
 


### PR DESCRIPTION
These fixes are mostly related to missing checks for libraries (especially `libxml`) and string concatenation errors for `CPPFLAGS`.