### PR TITLE
fbitdump/http_status_code: fixed uninitialized scalar variable

### DIFF
--- a/tools/fbitdump/src/plugins/http_status_code.c
+++ b/tools/fbitdump/src/plugins/http_status_code.c
@@ -111,7 +111,7 @@ void parse(char *input, char out[PLUGIN_BUFFER_SIZE], void *conf)
 	}
 	
 	// Return empty string if HTTP status description was not found
-	if (code == size) {
+	if (i == size) {
 		snprintf(out, PLUGIN_BUFFER_SIZE, "%s", "");
 		return;
 	}


### PR DESCRIPTION
This issue was introduced in #87.