### PR TITLE
Fixed incorrect variable names

### DIFF
--- a/base/headers/ipfixcol/input.h
+++ b/base/headers/ipfixcol/input.h
@@ -73,7 +73,6 @@
  */
 #define INPUT_INTR -2
 
-
 /**
  * \enum SOURCE_TYPE
  * \brief Type of the source of the input data.
@@ -82,21 +81,21 @@
  * information structure\endlink (like \link #input_info_network network\endlink
  * or \link #input_info_file file\endlink).
  */
-enum SOURCE_TYPE{
+enum SOURCE_TYPE {
 	SOURCE_TYPE_UDP,          /**< IPFIX over UDP */
 	SOURCE_TYPE_TCP,          /**< IPFIX over TCP */
 	SOURCE_TYPE_TCPTLS,       /**< IPFIX over TCP secured with TLS */
 	SOURCE_TYPE_SCTP,         /**< IPFIX over SCTP */
- 	SOURCE_TYPE_NF5,          /**< NetFlow v5 */
+	SOURCE_TYPE_NF5,          /**< NetFlow v5 */
 	SOURCE_TYPE_NF9,          /**< NetFlow v9 */
 	SOURCE_TYPE_IPFIX_FILE,   /**< IPFIX File Format */
 	SOURCE_TYPE_COUNT         /**< number of defined SOURCE_TYPEs */
 };
 
-enum SOURCE_STATUS{
-	SOURCE_STATUS_NEW,     /**< New source connected */
-	SOURCE_STATUS_OPENED,         /**< Received first data from source */
-	SOURCE_STATUS_CLOSED       /**< Source closed */
+enum SOURCE_STATUS {
+	SOURCE_STATUS_NEW,        /**< New source connected */
+	SOURCE_STATUS_OPENED,     /**< Received first data from source */
+	SOURCE_STATUS_CLOSED      /**< Source closed */
 };
 
 /**
@@ -117,13 +116,13 @@ struct __attribute__((__packed__)) input_info {
  */
 struct __attribute__((__packed__)) input_info_network {
 	enum SOURCE_TYPE type;    /**< type of source - #SOURCE_TYPE_UDP,
-	                           * #SOURCE_TYPE_TCP, #SOURCE_TYPE_TCPTLS,
-	                           * #SOURCE_TYPE_SCTP, #SOURCE_TYPE_NF5,
-	                           * #SOURCE_TYPE_NF9 */
+                               * #SOURCE_TYPE_TCP, #SOURCE_TYPE_TCPTLS,
+                               * #SOURCE_TYPE_SCTP, #SOURCE_TYPE_NF5,
+                               * #SOURCE_TYPE_NF9 */
 	int sequence_number;      /**< sequence number for current source */
-	enum SOURCE_STATUS status;  /**< source status - #SOURCE_STATUS_OPENED,
-	                           * #SOURCE_STATUS_NEW, #SOURCE_STATUS_CLOSED */
-	uint32_t odid;                 /**< Observation Domain ID of source */
+	enum SOURCE_STATUS status;/**< source status - #SOURCE_STATUS_OPENED,
+							   * #SOURCE_STATUS_NEW, #SOURCE_STATUS_CLOSED */
+	uint32_t odid;            /**< Observation Domain ID of source */
 	uint8_t l3_proto;         /**< IP protocol byte */
 	union {
 		struct in6_addr ipv6;
@@ -136,16 +135,16 @@ struct __attribute__((__packed__)) input_info_network {
 	uint16_t src_port;        /**< source transport port in host byte order */
 	uint16_t dst_port;        /**< destination transport port in host byte order */
 	void *exporter_cert;      /**< X.509 certificate used by exporter when
-	                           * using TLS/DTLS */
+                               * using TLS/DTLS */
 	void *collector_cert;     /**< X.509 certificate used by collector when
-	                           * using TLS/DTLS */
-    char *template_life_time;           /**< value templateLifeTime from plugin 
+                               * using TLS/DTLS */
+	char *template_life_time;           /**< value templateLifeTime from plugin
                                          * config xml */
-    char *options_template_life_time;   /**< value optionsTemplateLifeTime 
+	char *options_template_life_time;   /**< value optionsTemplateLifeTime
                                          * from config xml */
-    char *template_life_packet;         /**< value templateLifePacket from 
+	char *template_life_packet;         /**< value templateLifePacket from
                                          * plugin config xml*/
-    char *options_template_life_packet; /**< value optionsTemplateLifePacket
+	char *options_template_life_packet; /**< value optionsTemplateLifePacket
                                          * from plugin config xml */
 };
 
@@ -154,12 +153,12 @@ struct __attribute__((__packed__)) input_info_network {
  * \brief Input information structure specific for file based data sources.
  */
 struct __attribute__((__packed__)) input_info_file {
-	enum SOURCE_TYPE type;    /**< type of source - #SOURCE_TYPE_IPFIX_FILE */
-	int sequence_number;      /**< sequence number for current source */
-	enum SOURCE_STATUS status;  /**< source status - #SOURCE_STATUS_OPENED,
-		                           * #SOURCE_STATUS_NEW, #SOURCE_STATUS_CLOSED */
-	uint32_t odid;                 /**< Observation Domain ID of source */
-	char *name;               /**< name of the input file */
+	enum SOURCE_TYPE type;     /**< type of source - #SOURCE_TYPE_IPFIX_FILE */
+	int sequence_number;       /**< sequence number for current source */
+	enum SOURCE_STATUS status; /**< source status - #SOURCE_STATUS_OPENED,
+                                * #SOURCE_STATUS_NEW, #SOURCE_STATUS_CLOSED */
+	uint32_t odid;             /**< Observation Domain ID of source */
+	char *name;                /**< name of the input file */
 };
 
 /**

--- a/base/headers/ipfixcol/storage.h
+++ b/base/headers/ipfixcol/storage.h
@@ -46,8 +46,8 @@
 #include "api.h"
 
 #define MSG_MAX_LENGTH          65535
-#define MSG_MAX_OTEMPLATES      1024
-#define MSG_MAX_TEMPLATES       1024
+#define MSG_MAX_OTEMPL_SETS     1024
+#define MSG_MAX_TEMPL_SETS      1024
 #define MSG_MAX_DATA_COUPLES    1023
 
 /**
@@ -119,15 +119,15 @@ struct __attribute__((__packed__)) ipfix_message {
 	enum PLUGIN_STATUS                plugin_status;
 	int plugin_id;
 	/** Number of data records in message */
-	uint16_t 						  data_records_count;
+	uint16_t                          data_records_count;
 	/** Number of template records in message */
-	uint16_t						  templ_records_count;
+	uint16_t                          templ_records_count;
 	/** Number of options template records in message */
-	uint16_t						  opt_templ_records_count;
+	uint16_t                          opt_templ_records_count;
 	/** List of Template Sets in the packet */
-	struct ipfix_template_set         *templ_set[MSG_MAX_TEMPLATES];
+	struct ipfix_template_set         *templ_set[MSG_MAX_TEMPL_SETS];
 	/** List of Options Template Sets in the packet */
-	struct ipfix_options_template_set *opt_templ_set[MSG_MAX_OTEMPLATES];
+	struct ipfix_options_template_set *opt_templ_set[MSG_MAX_OTEMPL_SETS];
 	/** List of Data Sets (with a link to corresponding template) in the packet */
 	struct data_template_couple       data_couple[MSG_MAX_DATA_COUPLES];
 	/** Pointer to the live profile */

--- a/base/src/intermediate/filter/filter.c
+++ b/base/src/intermediate/filter/filter.c
@@ -585,14 +585,14 @@ void filter_add_template_sets(struct ipfix_message *msg, uint8_t *ptr, int *offs
 	int length, i;
 
 	/* Copy template sets */
-	for (i = 0; i < MSG_MAX_TEMPLATES && msg->templ_set[i]; ++i) {
+	for (i = 0; i < MSG_MAX_TEMPL_SETS && msg->templ_set[i]; ++i) {
 		length = ntohs(msg->templ_set[i]->header.length);
 		memcpy(ptr + *offset, msg->templ_set[i], length);
 		*offset += length;
 	}
 
 	/* Copy options template sets */
-	for (i = 0; i < MSG_MAX_OTEMPLATES && msg->opt_templ_set[i]; ++i) {
+	for (i = 0; i < MSG_MAX_OTEMPL_SETS && msg->opt_templ_set[i]; ++i) {
 		length = ntohs(msg->opt_templ_set[i]->header.length);
 		memcpy(ptr + *offset, msg->opt_templ_set[i], length);
 		*offset += length;

--- a/base/src/intermediate/joinflows/joinflows_ip.c
+++ b/base/src/intermediate/joinflows/joinflows_ip.c
@@ -898,7 +898,7 @@ int intermediate_process_message(void *config, void *message)
 
 	/* Process templates */
 	proc.type = TM_TEMPLATE;
-	for (i = 0; i < MSG_MAX_TEMPLATES && msg->templ_set[i]; ++i) {
+	for (i = 0; i < MSG_MAX_TEMPL_SETS && msg->templ_set[i]; ++i) {
 		prevoffset = proc.offset;
 		memcpy(proc.msg + proc.offset, &(msg->templ_set[i]->header), 4);
 		proc.offset += 4;
@@ -920,7 +920,7 @@ int intermediate_process_message(void *config, void *message)
 	proc.trecords = 0;
 	/* Process option templates */
 	proc.type = TM_OPTIONS_TEMPLATE;
-	for (i = 0; i < MSG_MAX_OTEMPLATES && msg->opt_templ_set[i]; ++i) {
+	for (i = 0; i < MSG_MAX_OTEMPL_SETS && msg->opt_templ_set[i]; ++i) {
 		prevoffset = proc.offset;
 		memcpy(proc.msg + proc.offset, &(msg->opt_templ_set[i]->header), 4);
 		proc.offset += 4;

--- a/base/src/intermediate/odip/odip.c
+++ b/base/src/intermediate/odip/odip.c
@@ -74,7 +74,6 @@ struct odip_ip_config {
 	struct ipfix_template_mgr *tm; /* Template Manager */
 };
 
-
 /* structure for processing message */
 struct odip_processor {
 	uint8_t *msg;
@@ -287,7 +286,7 @@ int intermediate_process_message(void *config, void *message)
 	
 	/* process template records */
 	proc.type = TM_TEMPLATE;
-	for (i = 0; i < MSG_MAX_TEMPLATES && msg->templ_set[i]; ++i) {
+	for (i = 0; i < MSG_MAX_TEMPL_SETS && msg->templ_set[i]; ++i) {
 		prevoffset = proc.offset;
 		memcpy(proc.msg + proc.offset, &(msg->templ_set[i]->header), 4);
 		proc.offset += 4;
@@ -306,7 +305,7 @@ int intermediate_process_message(void *config, void *message)
 	
 	/* Process option templates */
 	proc.type = TM_OPTIONS_TEMPLATE;
-	for (i = 0; i < MSG_MAX_OTEMPLATES && msg->opt_templ_set[i]; ++i) {
+	for (i = 0; i < MSG_MAX_OTEMPL_SETS && msg->opt_templ_set[i]; ++i) {
 		prevoffset = proc.offset;
 		memcpy(proc.msg + proc.offset, &(msg->opt_templ_set[i]->header), 4);
 		proc.offset += 4;

--- a/base/src/ipfix_message.c
+++ b/base/src/ipfix_message.c
@@ -74,7 +74,6 @@ static struct offset_field offsets[] = {
 #define read32(ptr) (*((uint32_t *) (ptr)))
 #define read64(ptr) (*((uint64_t *) (ptr)))
 
-
 /**
  * \brief Create ipfix_message structure from data in memory
  *

--- a/base/src/preprocessor.c
+++ b/base/src/preprocessor.c
@@ -463,7 +463,7 @@ static uint32_t preprocessor_process_templates(struct ipfix_message *msg)
 	preprocessor_udp_init((struct input_info_network *) msg->input_info, &udp_conf);
 
 	/* check for new templates */
-	for (i = 0; i < MSG_MAX_TEMPLATES && msg->templ_set[i]; i++) {
+	for (i = 0; i < MSG_MAX_TEMPL_SETS && msg->templ_set[i]; i++) {
 		ptr = (uint8_t*) &msg->templ_set[i]->first_record;
 		while (ptr < (uint8_t*) msg->templ_set[i] + ntohs(msg->templ_set[i]->header.length)) {
 			max_len = ((uint8_t *) msg->templ_set[i] + ntohs(msg->templ_set[i]->header.length)) - ptr;
@@ -478,7 +478,7 @@ static uint32_t preprocessor_process_templates(struct ipfix_message *msg)
 	}
 
 	/* check for new option templates */
-	for (i = 0; i < MSG_MAX_OTEMPLATES && msg->opt_templ_set[i]; i++) {
+	for (i = 0; i < MSG_MAX_OTEMPL_SETS && msg->opt_templ_set[i]; i++) {
 		ptr = (uint8_t*) &msg->opt_templ_set[i]->first_record;
 		max_len = ((uint8_t *) msg->opt_templ_set[i] + ntohs(msg->opt_templ_set[i]->header.length)) - ptr;
 		while (ptr < (uint8_t*) msg->opt_templ_set[i] + ntohs(msg->opt_templ_set[i]->header.length)) {

--- a/base/src/storage/forwarding/forwarding.c
+++ b/base/src/storage/forwarding/forwarding.c
@@ -534,14 +534,14 @@ void *msg_to_packet(const struct ipfix_message *msg, int *packet_length)
 	offset += IPFIX_HEADER_LENGTH;
 
 	/* Copy template sets */
-	for (i = 0; i < MSG_MAX_TEMPLATES && msg->templ_set[i]; ++i) {
+	for (i = 0; i < MSG_MAX_TEMPL_SETS && msg->templ_set[i]; ++i) {
 		len = ntohs(msg->templ_set[i]->header.length);
 		memcpy(packet + offset, msg->templ_set[i], len);
 		offset += len;
 	}
 
 	/* Copy option template sets */
-	for (i = 0; i < MSG_MAX_OTEMPLATES && msg->opt_templ_set[i]; ++i) {
+	for (i = 0; i < MSG_MAX_OTEMPL_SETS && msg->opt_templ_set[i]; ++i) {
 		len = ntohs(msg->opt_templ_set[i]->header.length);
 		memcpy(packet + offset, msg->opt_templ_set[i], len);
 		offset += len;
@@ -711,13 +711,13 @@ int forwarding_record_sent(forwarding *conf, struct ipfix_template_record *rec, 
 void forwarding_remove_empty_sets(struct ipfix_message *msg)
 {
 	int i, j, len;
-	for (i = 0, j = 0; i < MSG_MAX_TEMPLATES && msg->templ_set[i]; ++i) {
+	for (i = 0, j = 0; i < MSG_MAX_TEMPL_SETS && msg->templ_set[i]; ++i) {
 		len = ntohs(msg->templ_set[i]->header.length);
 		if (len <= 4) {
 			/* Set correct message length */
 			msg->pkt_header->length = htons(ntohs(msg->pkt_header->length) - len);
 			/* Shift all template sets behind this (there must not be hole) */
-			for (j = i; j < MSG_MAX_TEMPLATES - 1 && msg->templ_set[j]; ++j) {
+			for (j = i; j < MSG_MAX_TEMPL_SETS - 1 && msg->templ_set[j]; ++j) {
 				msg->templ_set[j] = msg->templ_set[j + 1];
 			}
 		}
@@ -762,7 +762,7 @@ int forwarding_remove_sent_templates(forwarding *conf, const struct ipfix_messag
 
 	/* Copy unsent templates to new message */
 	proc.type = TM_TEMPLATE;
-	for (i = 0; i < MSG_MAX_TEMPLATES && msg->templ_set[i] != NULL; ++i) {
+	for (i = 0; i < MSG_MAX_TEMPL_SETS && msg->templ_set[i] != NULL; ++i) {
 		prevo = proc.offset;
 		memcpy(proc.msg + proc.offset, &(msg->templ_set[i]->header), 4);
 		proc.offset += 4;
@@ -780,7 +780,7 @@ int forwarding_remove_sent_templates(forwarding *conf, const struct ipfix_messag
 
 	/* Copy unsent option templates to new message */
 	proc.type = TM_OPTIONS_TEMPLATE;
-	for (i = 0; i < MSG_MAX_OTEMPLATES && msg->opt_templ_set[i]; ++i) {
+	for (i = 0; i < MSG_MAX_OTEMPL_SETS && msg->opt_templ_set[i]; ++i) {
 		prevo = proc.offset;
 		memcpy(proc.msg + proc.offset, &(msg->opt_templ_set[i]->header), 4);
 		proc.offset += 4;
@@ -809,10 +809,10 @@ void forwarding_add_set(struct ipfix_message *msg, struct ipfix_template_set *se
 	int i;
 
 	// Find first empty slot
-	for (i = 0; i < MSG_MAX_TEMPLATES && msg->templ_set[i]; ++i);
+	for (i = 0; i < MSG_MAX_TEMPL_SETS && msg->templ_set[i]; ++i);
 
-	if (i == MSG_MAX_TEMPLATES) {
-		MSG_ERROR(msg_module, "Could not add template to IPFIX message, because message already features %u templates", MSG_MAX_TEMPLATES);
+	if (i == MSG_MAX_TEMPL_SETS) {
+		MSG_ERROR(msg_module, "Could not add template to IPFIX message, because message already features %u templates", MSG_MAX_TEMPL_SETS);
 	} else {
 		msg->templ_set[i] = set;
 		msg->pkt_header->length = htons(ntohs(msg->pkt_header->length) + ntohs(set->header.length));

--- a/plugins/input/nfdump/nfinput.c
+++ b/plugins/input/nfdump/nfinput.c
@@ -558,7 +558,7 @@ void *message_to_packet(const struct ipfix_message *msg, int *packet_length)
 	offset += IPFIX_HEADER_LENGTH;
 
 	/* Copy template sets */
-	for (i = 0; i < MSG_MAX_TEMPLATES && msg->templ_set[i]; ++i) {
+	for (i = 0; i < MSG_MAX_TEMPL_SETS && msg->templ_set[i]; ++i) {
 		aux_header = &(msg->templ_set[i]->header);
 		len = ntohs(aux_header->length);
 		for (c = 0; c < len; c += 4) {
@@ -569,7 +569,7 @@ void *message_to_packet(const struct ipfix_message *msg, int *packet_length)
 	}
 
 	/* Copy template sets */
-	for (i = 0; i < MSG_MAX_OTEMPLATES && msg->opt_templ_set[i]; ++i) {
+	for (i = 0; i < MSG_MAX_OTEMPL_SETS && msg->opt_templ_set[i]; ++i) {
 		aux_header = &(msg->opt_templ_set[i]->header);
 		len = ntohs(aux_header->length);
 		for (c = 0; c < len; c += 4) {


### PR DESCRIPTION
Several variables in `storage.h` were referring to 'records' while they should actually refer to 'sets':

* `MSG_MAX_TEMPLATES` > `MSG_MAX_TEMPL_SETS`
* `MSG_MAX_OTEMPLATES` > `MSG_MAX_OPT_TEMPL_SETS`
* `data_records_count` > `data_sets_count`
* `templ_records_count` > `templ_sets_count`
* `opt_templ_records_count` > `opt_templ_sets_count`