### PR TITLE
Improvements to anonymization intermediate plugin

### DIFF
--- a/base/src/ipfix_message.c
+++ b/base/src/ipfix_message.c
@@ -176,12 +176,11 @@ struct ipfix_message *message_create_clone(struct ipfix_message *msg)
 		return NULL;
 	}
 
-	packet = (uint8_t *) malloc(ntohs(msg->pkt_header->length));
+	packet = (uint8_t *) calloc(1, ntohs(msg->pkt_header->length));
 	if (!packet) {
 		MSG_ERROR(msg_module, "Unable to allocate memory (%s:%d)", __FILE__, __LINE__);
 		return NULL;
 	}
-	memset(packet, 0, sizeof(ntohs(msg->pkt_header->length)));
 
 	message = message_create_from_mem(packet, msg->pkt_header->length, msg->input_info, msg->source_status);
 	if (!message) {
@@ -300,12 +299,11 @@ uint8_t **get_data_records(struct ipfix_data_set *data_set, struct ipfix_templat
 	uint16_t records_index = 0;
 
 	/* TODO - make it clever */
-	records = (uint8_t **) malloc(MSG_MAX_DATA_COUPLES * sizeof(uint8_t *));
+	records = (uint8_t **) calloc(MSG_MAX_DATA_COUPLES, sizeof(uint8_t *));
 	if (records == NULL) {
-		MSG_ERROR(msg_module, "Unable to allocate memory (%s:%d)", __FILE__, __LINE__);
+		MSG_ERROR(msg_module, "Memory allocation failed (%s:%d)", __FILE__, __LINE__);
 		return (uint8_t **) NULL;
 	}
-	memset(records, 0, MSG_MAX_DATA_COUPLES * sizeof(uint8_t *));
 
 	min_record_length = tmplt->data_length;
 	offset = 0;
@@ -321,6 +319,7 @@ uint8_t **get_data_records(struct ipfix_data_set *data_set, struct ipfix_templat
 		data_record = (((uint8_t *) data_set) + offset);
 		records[records_index] = data_record;
 		offset += get_next_data_record_offset(data_record, tmplt);
+		++records_index;
 	}
 
 	return records;
@@ -337,20 +336,18 @@ struct ipfix_message *message_create_empty()
 	struct ipfix_message *message;
 	struct ipfix_header *header;
 
-	message = (struct ipfix_message *) malloc(sizeof(*message));
+	message = (struct ipfix_message *) calloc(1, sizeof(*message));
 	if (!message) {
 		MSG_ERROR(msg_module, "Memory allocation failed (%s:%d)", __FILE__, __LINE__);
 		return NULL;
 	}
-	memset(message, 0, sizeof(*message));
 
-	header = (struct ipfix_header *) malloc(sizeof(*header));
+	header = (struct ipfix_header *) calloc(1, sizeof(*header));
 	if (!header) {
 		MSG_ERROR(msg_module, "Memory allocation failed (%s:%d)", __FILE__, __LINE__);
 		free(message);
 		return NULL;
 	}
-	memset(header, 0, sizeof(*header));
 
 	message->pkt_header = header;
 


### PR DESCRIPTION
The contributions of this pull request can be summarized as follows:
* Fixed a bug in `get_data_records` (`ipfix_message.c`) that caused the function to always return only the first data record (index: 0) of the dataset. This caused the anonymization plugin to always anonymize the first data record only.
* Anonymization plugin now allows for explicit key definition in `startup.xml` with `key` element.
* Many minor improvements (syntax improvements, memory leak fixes, etc.) in anonymization plugin.