### PR TITLE
Template manager: implemented template_get_field_offset

### DIFF
--- a/base/headers/ipfixcol/templates.h
+++ b/base/headers/ipfixcol/templates.h
@@ -266,14 +266,26 @@ API void tm_remove_all_odid_templates(struct ipfix_template_mgr *tm, uint32_t od
 API struct ipfix_template_mgr *tm_create();
 
 /**
- * \brief Determines whether specific template contains given field
+ * \brief Determines whether specific template contains given field and returns
+ * the field's offset.
  *
- * \param[in]  templ template
- * \param[in]  field field
- * \return 0 on success, negative value otherwise.
+ * \param[in] templ Template
+ * \param[in] field Field ID. In case of an enterprise-specific field, the
+ * enterprise bit must be set to 1
+ * \return Field offset on success, negative value otherwise
  */
 API int template_contains_field(struct ipfix_template *templ, uint16_t field);
 
+/**
+ * \brief Determines whether specific template contains given field and returns
+ * the field's offset.
+ *
+ * \param[in] templ Template
+ * \param[in] eid Enterprise ID (zero in case the field is not enterprise-specific)
+ * \param[in] fid Field ID
+ * \return Field offset on success, negative value otherwise
+ */
+API int template_get_field_offset(struct ipfix_template *templ, uint16_t eid, uint16_t fid);
 
 /**
  * \brief Increment number of references to template

--- a/base/src/ipfix_message.c
+++ b/base/src/ipfix_message.c
@@ -120,43 +120,43 @@ struct ipfix_message *message_create_from_mem(void *msg, int len, struct input_i
 	}
 
 	/* process IPFIX msg and fill up the ipfix_message structure */
-    uint8_t *p = msg + IPFIX_HEADER_LENGTH;
-    int t_set_count = 0;
-    int ot_set_count = 0;
-    int d_set_count = 0;
-    struct ipfix_set_header *set_header;
-    while (p < (uint8_t*) msg + pktlen) {
-        set_header = (struct ipfix_set_header*) p;
-        if ((uint8_t *) p + ntohs(set_header->length) > (uint8_t *) msg + pktlen) {
-        	MSG_WARNING(msg_module, "[%u] Malformed IPFIX message detected (bad length); skipping message...", odid);
-        	free(message);
-        	return NULL;
-        }
-        switch (ntohs(set_header->flowset_id)) {
-            case IPFIX_TEMPLATE_FLOWSET_ID:
-                message->templ_set[t_set_count++] = (struct ipfix_template_set *) set_header;
-                break;
-            case IPFIX_OPTION_FLOWSET_ID:
-                 message->opt_templ_set[ot_set_count++] = (struct ipfix_options_template_set *) set_header;
-                break;
-            default:
-                if (ntohs(set_header->flowset_id) < IPFIX_MIN_RECORD_FLOWSET_ID) {
-                	MSG_WARNING(msg_module, "[%u] Unknown Set ID %d", odid, ntohs(set_header->flowset_id));
-                } else {
-                    message->data_couple[d_set_count++].data_set = (struct ipfix_data_set*) set_header;
-                }
-                break;
-        }
+	uint8_t *p = msg + IPFIX_HEADER_LENGTH;
+	int t_set_count = 0;
+	int ot_set_count = 0;
+	int d_set_count = 0;
+	struct ipfix_set_header *set_header;
+	while (p < (uint8_t*) msg + pktlen) {
+		set_header = (struct ipfix_set_header*) p;
+		if ((uint8_t *) p + ntohs(set_header->length) > (uint8_t *) msg + pktlen) {
+			MSG_WARNING(msg_module, "[%u] Malformed IPFIX message detected (bad length); skipping message...", odid);
+			free(message);
+			return NULL;
+		}
+		switch (ntohs(set_header->flowset_id)) {
+			case IPFIX_TEMPLATE_FLOWSET_ID:
+				message->templ_set[t_set_count++] = (struct ipfix_template_set *) set_header;
+				break;
+			case IPFIX_OPTION_FLOWSET_ID:
+				 message->opt_templ_set[ot_set_count++] = (struct ipfix_options_template_set *) set_header;
+				break;
+			default:
+				if (ntohs(set_header->flowset_id) < IPFIX_MIN_RECORD_FLOWSET_ID) {
+					MSG_WARNING(msg_module, "[%u] Unknown Set ID %d", odid, ntohs(set_header->flowset_id));
+				} else {
+					message->data_couple[d_set_count++].data_set = (struct ipfix_data_set*) set_header;
+				}
+				break;
+		}
 
-        /* if length is wrong and pointer does not move, stop processing the message */
-        if (ntohs(set_header->length) == 0) {
-        	break;
-        }
+		/* if length is wrong and pointer does not move, stop processing the message */
+		if (ntohs(set_header->length) == 0) {
+			break;
+		}
 
-        p += ntohs(set_header->length);
-    }
+		p += ntohs(set_header->length);
+	}
 
-    return message;
+	return message;
 }
 
 /**
@@ -201,7 +201,6 @@ struct ipfix_message *message_create_clone(struct ipfix_message *msg)
  */
 int message_get_data(uint8_t **dest, uint8_t *source, int len)
 {
-
 	*dest = (uint8_t *) malloc(sizeof(uint8_t) * len);
 	if (!*dest) {
 		MSG_ERROR(msg_module, "Unable to allocate memory (%s:%d)", __FILE__, __LINE__);
@@ -224,7 +223,6 @@ int message_get_data(uint8_t **dest, uint8_t *source, int len)
 int message_set_data(uint8_t *dest, uint8_t *source, int len)
 {
 	memcpy(dest, source, len);
-
 	return 0;
 }
 
@@ -777,29 +775,3 @@ struct metadata *message_copy_metadata(struct ipfix_message *src)
 
 	return metadata;
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
The use of `template_contains_field` is rather cumbersome:
* The name of the method suggests it to return a boolean-typed variable, while it (nowadays) returns a field offset.
* When using it for enterprise-specific fields, one has to guess (or check the source code) that the enterprise bit must be set to 1 in the `field` argument.
* In case there are multiple enterprise-specific fields, from different enterprises, with the same field ID, this method returns the wrong offset.

Since there is quite some code that relies on `template_contains_field` (for obtaining field offsets based on templates) I decided to not touch that function, but create a new function that does the right job. This new function, `template_get_field_offset`, takes also an enterprise ID and considers it when finding field offsets.