### PR TITLE
Output Manager: refactored statistics management

### DIFF
--- a/base/headers/ipfixcol/input.h
+++ b/base/headers/ipfixcol/input.h
@@ -64,12 +64,12 @@
 #define INPUT_CLOSED 0
 /**
  * \def INPUT_ERROR
- * An error occured in get_packet function
+ * Error occured in get_packet() function
  */
 #define INPUT_ERROR -1
 /**
  * \def INPUT_INTR
- * Function interupted by SIGINT
+ * Function interrupted by SIGINT
  */
 #define INPUT_INTR -2
 
@@ -82,20 +82,20 @@
  * or \link #input_info_file file\endlink).
  */
 enum SOURCE_TYPE {
-	SOURCE_TYPE_UDP,          /**< IPFIX over UDP */
-	SOURCE_TYPE_TCP,          /**< IPFIX over TCP */
-	SOURCE_TYPE_TCPTLS,       /**< IPFIX over TCP secured with TLS */
-	SOURCE_TYPE_SCTP,         /**< IPFIX over SCTP */
-	SOURCE_TYPE_NF5,          /**< NetFlow v5 */
-	SOURCE_TYPE_NF9,          /**< NetFlow v9 */
-	SOURCE_TYPE_IPFIX_FILE,   /**< IPFIX File Format */
-	SOURCE_TYPE_COUNT         /**< number of defined SOURCE_TYPEs */
+	SOURCE_TYPE_UDP,            /**< IPFIX over UDP */
+	SOURCE_TYPE_TCP,            /**< IPFIX over TCP */
+	SOURCE_TYPE_TCPTLS,         /**< IPFIX over TCP secured with TLS */
+	SOURCE_TYPE_SCTP,           /**< IPFIX over SCTP */
+	SOURCE_TYPE_NF5,            /**< NetFlow v5 */
+	SOURCE_TYPE_NF9,            /**< NetFlow v9 */
+	SOURCE_TYPE_IPFIX_FILE,     /**< IPFIX File Format */
+	SOURCE_TYPE_COUNT           /**< number of defined SOURCE_TYPEs */
 };
 
 enum SOURCE_STATUS {
-	SOURCE_STATUS_NEW,        /**< New source connected */
-	SOURCE_STATUS_OPENED,     /**< Received first data from source */
-	SOURCE_STATUS_CLOSED      /**< Source closed */
+	SOURCE_STATUS_NEW,          /**< New source connected */
+	SOURCE_STATUS_OPENED,       /**< Received first data from source */
+	SOURCE_STATUS_CLOSED        /**< Source closed */
 };
 
 /**
@@ -104,10 +104,12 @@ enum SOURCE_STATUS {
  * input information type.
  */
 struct __attribute__((__packed__)) input_info {
-	enum SOURCE_TYPE type;		/**< type of source defined by enum #SOURCE_TYPE */
-	uint32_t sequence_number;	/**< sequence number for current source */
-	enum SOURCE_STATUS status;	/**< source status defined by enum #SOURCE_STATUS */
-	uint32_t odid;				/**< Observation Domain ID of source */
+	enum SOURCE_TYPE type;      /**< type of source defined by enum #SOURCE_TYPE */
+	enum SOURCE_STATUS status;  /**< source status defined by enum #SOURCE_STATUS */
+	uint32_t sequence_number;   /**< sequence number for source */
+	uint32_t odid;              /**< observation domain ID of source */
+	uint64_t packets;           /**< packets for source */
+	uint64_t data_records;      /**< data records for source */
 };
 
 /**
@@ -115,29 +117,30 @@ struct __attribute__((__packed__)) input_info {
  * \brief Input information structure specific for network based data sources.
  */
 struct __attribute__((__packed__)) input_info_network {
-	enum SOURCE_TYPE type;    /**< type of source - #SOURCE_TYPE_UDP,
-                               * #SOURCE_TYPE_TCP, #SOURCE_TYPE_TCPTLS,
-                               * #SOURCE_TYPE_SCTP, #SOURCE_TYPE_NF5,
-                               * #SOURCE_TYPE_NF9 */
-	int sequence_number;      /**< sequence number for current source */
-	enum SOURCE_STATUS status;/**< source status - #SOURCE_STATUS_OPENED,
-							   * #SOURCE_STATUS_NEW, #SOURCE_STATUS_CLOSED */
-	uint32_t odid;            /**< Observation Domain ID of source */
-	uint8_t l3_proto;         /**< IP protocol byte */
+	enum SOURCE_TYPE type;      /**< type of source defined by enum #SOURCE_TYPE */
+	enum SOURCE_STATUS status;  /**< source status defined by enum #SOURCE_STATUS */
+	uint32_t sequence_number;   /**< sequence number for source */
+	uint32_t odid;              /**< observation domain ID of source */
+	uint64_t packets;           /**< packets for source */
+	uint64_t data_records;      /**< data records for source */
+
 	union {
 		struct in6_addr ipv6;
 		struct in_addr ipv4;
-	} src_addr;               /**< source IP address */
+	} src_addr;                 /**< source IP address */
+
 	union {
 		struct in6_addr ipv6;
 		struct in_addr ipv4;
-	} dst_addr;               /**< destination IP address*/
-	uint16_t src_port;        /**< source transport port in host byte order */
-	uint16_t dst_port;        /**< destination transport port in host byte order */
-	void *exporter_cert;      /**< X.509 certificate used by exporter when
-                               * using TLS/DTLS */
-	void *collector_cert;     /**< X.509 certificate used by collector when
-                               * using TLS/DTLS */
+	} dst_addr;                 /**< destination IP address*/
+
+	uint8_t l3_proto;           /**< IP protocol byte */
+	uint16_t src_port;          /**< source transport port in host byte order */
+	uint16_t dst_port;          /**< destination transport port in host byte order */
+	void *exporter_cert;        /**< X.509 certificate used by exporter when
+                                 * using TLS/DTLS */
+	void *collector_cert;       /**< X.509 certificate used by collector when
+                                 * using TLS/DTLS */
 	char *template_life_time;           /**< value templateLifeTime from plugin
                                          * config xml */
 	char *options_template_life_time;   /**< value optionsTemplateLifeTime
@@ -153,12 +156,13 @@ struct __attribute__((__packed__)) input_info_network {
  * \brief Input information structure specific for file based data sources.
  */
 struct __attribute__((__packed__)) input_info_file {
-	enum SOURCE_TYPE type;     /**< type of source - #SOURCE_TYPE_IPFIX_FILE */
-	int sequence_number;       /**< sequence number for current source */
-	enum SOURCE_STATUS status; /**< source status - #SOURCE_STATUS_OPENED,
-                                * #SOURCE_STATUS_NEW, #SOURCE_STATUS_CLOSED */
-	uint32_t odid;             /**< Observation Domain ID of source */
-	char *name;                /**< name of the input file */
+	enum SOURCE_TYPE type;      /**< type of source - #SOURCE_TYPE_IPFIX_FILE */
+	enum SOURCE_STATUS status;  /**< source status defined by enum #SOURCE_STATUS */
+	uint32_t sequence_number;   /**< sequence number for source */
+	uint32_t odid;              /**< observation domain ID of source */
+	uint64_t packets;           /**< packets for source */
+	uint64_t data_records;      /**< data records for source */
+	char *name;                 /**< name of the input file */
 };
 
 /**
@@ -213,4 +217,3 @@ API int input_close(void **config);
 #endif /* IPFIXCOL_INPUT_H_ */
 
 /**@}*/
-

--- a/base/src/configurator.c
+++ b/base/src/configurator.c
@@ -329,7 +329,7 @@ int config_add_input(configurator *config, struct plugin_config *plugin, int ind
 		goto err;
 	}
 	
-	/* check api version */
+	/* Check API version */
 	unsigned int *plugin_api_version = (unsigned int *) dlsym(config->input.dll_handler, "ipfixcol_api_version");
 	if (!plugin_api_version) { /* no api version symbol */
 		MSG_ERROR(msg_module, "[%d] Unable to load plugin '%s'; API version number is missing...",
@@ -341,7 +341,7 @@ int config_add_input(configurator *config, struct plugin_config *plugin, int ind
 		goto err;
 	}
 
-	/* prepare Input API routines */
+	/* Prepare Input API routines */
 	config->input.init = dlsym(config->input.dll_handler, "input_init");
 	if (!config->input.init) {
 		MSG_ERROR(msg_module, "[%d] Unable to load input xml_conf (%s)", config->proc_id, dlerror());
@@ -360,10 +360,10 @@ int config_add_input(configurator *config, struct plugin_config *plugin, int ind
 		goto err;
 	}
 
-	/* extend the process name variable by input name */
+	/* Extend the process name variable by input name */
 	snprintf(config->process_name, 16, "%s:%s", PACKAGE, plugin->conf.name);
 
-	/* set the process name to reflect the input name */
+	/* Set the process name to reflect the input name */
 	prctl(PR_SET_NAME, config->process_name, 0, 0, 0);
 	
 	/* initialize plugin */
@@ -415,10 +415,10 @@ int config_add_inter(configurator *config, struct plugin_config *plugin, int ind
 		goto err;
 	}
 	
-	/* set intermediate thread name */
+	/* Set intermediate thread name */
 	snprintf(im_plugin->thread_name, 16, "med:%s", plugin->conf.name);
 	
-	/* check api version */
+	/* Check API version */
 	unsigned int *plugin_api_version = (unsigned int *) dlsym(im_plugin->dll_handler, "ipfixcol_api_version");
 	if (!plugin_api_version) { /* no api version symbol */
 		MSG_ERROR(msg_module, "[%d] Unable to load plugin '%s'; API version number is missing...",
@@ -430,7 +430,7 @@ int config_add_inter(configurator *config, struct plugin_config *plugin, int ind
 		goto err;
 	}
 
-	/* prepare Input API routines */
+	/* Prepare Input API routines */
 	im_plugin->intermediate_process_message = dlsym(im_plugin->dll_handler, "intermediate_process_message");
 	if (!im_plugin->intermediate_process_message) {
 		MSG_ERROR(msg_module, "Unable to load intermediate xml_conf (%s)", dlerror());
@@ -533,10 +533,10 @@ int config_add_storage(configurator *config, struct plugin_config *plugin, int i
 		goto err;
 	}
 	
-	/* set storage thread name */
+	/* Set storage thread name */
 	snprintf(st_plugin->thread_name, 16, "out:%s", plugin->conf.name);
 	
-	/* check api version */
+	/* Check API version */
 	unsigned int *plugin_api_version = (unsigned int *) dlsym(st_plugin->dll_handler, "ipfixcol_api_version");
 	if (!plugin_api_version) { /* no api version symbol */
 		MSG_ERROR(msg_module, "[%d] Unable to load plugin '%s'; API version number is missing...",
@@ -548,7 +548,7 @@ int config_add_storage(configurator *config, struct plugin_config *plugin, int i
 		goto err;
 	}
 
-	/* prepare Input API routines */
+	/* Prepare Input API routines */
 	st_plugin->init = dlsym(st_plugin->dll_handler, "storage_init");
 	if (!st_plugin->init) {
 		MSG_ERROR(msg_module, "[%d] Unable to load storage xml_conf (%s)", config->proc_id, dlerror());

--- a/base/src/data_manager.c
+++ b/base/src/data_manager.c
@@ -106,7 +106,7 @@ static void* storage_plugin_thread(void *cfg)
     /* loop will break upon receiving NULL from buffer */
 	while (!stop) {
 		/* get next data */
-		msg = rbuffer_read (config->thread_config->queue, &index);
+		msg = rbuffer_read(config->thread_config->queue, &index);
 		if (msg == NULL) {
 			MSG_NOTICE("storage plugin thread", "[%u] No more data from Data Manager", config->odid);
             break;
@@ -133,7 +133,7 @@ static void* storage_plugin_thread(void *cfg)
 			break;
 		default: /* DATA */
 			if (can_read) {
-				config->store (config->config, msg, config->thread_config->template_mgr);
+				config->store(config->config, msg, config->thread_config->template_mgr);
 				rbuffer_remove_reference(config->thread_config->queue, index, 1);
 			}
 			break;
@@ -183,8 +183,8 @@ int data_manager_add_plugin(struct data_manager_config *config, struct storage *
 	plugin = config->storage_plugins[config->plugins_count];
 	
 	/* Initiate storage plugin */
-	xmlDocDumpMemory (plugin->xml_conf->xmldata, &plugin_params, NULL);
-	retval = plugin->init ((char*) plugin_params, &(plugin->config));
+	xmlDocDumpMemory(plugin->xml_conf->xmldata, &plugin_params, NULL);
+	retval = plugin->init((char*) plugin_params, &(plugin->config));
 	xmlFree(plugin_params);
 	
 	if (retval != 0) {

--- a/base/src/output_manager.c
+++ b/base/src/output_manager.c
@@ -133,11 +133,11 @@ void sig_handler(int s)
  *
  * \todo: improve search e.g. by some kind of sorting data_managers
  *
- * @param[in] id Observation domain ID of wanted Data manager.
- * @return Desired Data manager's configuration structure if exists, NULL if
+ * \param[in] id Observation domain ID of wanted Data manager.
+ * \return Desired Data Manager configuration structure if exists, NULL if
  * there is no Data manager for specified Observation domain ID
  */
-static struct data_manager_config *get_data_mngmt_config (uint32_t id, struct data_manager_config *data_mngmts)
+static struct data_manager_config *get_data_mngmt_config(uint32_t id, struct data_manager_config *data_mngmts)
 {
 	struct data_manager_config *aux_cfg = data_mngmts;
 
@@ -291,7 +291,7 @@ int output_manager_remove_plugin(int id)
 		return 0;
 	}
 	
-	/* Kill all it's instances */
+	/* Kill all its instances */
 	if (plugin->xml_conf->observation_domain_id) {
 		/* Has ODID - max. 1 instance */
 		data_mgr = get_data_mngmt_config(atol(plugin->xml_conf->observation_domain_id), conf->data_managers);
@@ -312,7 +312,7 @@ int output_manager_remove_plugin(int id)
 }
 
 /**
- * \brief Output Managers thread
+ * \brief Output Manager thread
  *
  * @param[in] config configuration structure
  * @return NULL
@@ -326,7 +326,7 @@ static void *output_manager_plugin_thread(void* config)
 	conf = (struct output_manager_config *) config;
 	index = conf->in_queue->read_offset;
 
-	/* set the thread name to reflect the configuration */
+	/* Set thread name to reflect the configuration */
 	prctl(PR_SET_NAME, "ipfixcol OM", 0, 0, 0);
 
 	/* loop will break upon receiving NULL from buffer */
@@ -345,7 +345,7 @@ static void *output_manager_plugin_thread(void* config)
 				continue;
 			}
 			
-			/* End manager */
+			/* Stop manager */
 			break;
 		}
 
@@ -360,7 +360,7 @@ static void *output_manager_plugin_thread(void* config)
 		data_config = get_data_mngmt_config(msg->input_info->odid, conf->data_managers);
 		if (data_config == NULL) {
 			/*
-			 * no data manager config for this observation domain ID found -
+			 * No data manager config for this observation domain ID found -
 			 * we have a new observation domain ID, so create new data manager for
 			 * it
 			 */
@@ -372,7 +372,7 @@ static void *output_manager_plugin_thread(void* config)
 				continue;
 			}
 
-			/* add config to data_mngmts structure */
+			/* Add config to data_mngmts structure */
 			output_manager_insert(conf, data_config);
 
 			MSG_NOTICE(msg_module, "[%u] Data Manager created", msg->input_info->odid);
@@ -399,13 +399,13 @@ static void *output_manager_plugin_thread(void* config)
 		
 		/* Write data into input queue of Storage Plugins */
 		if (rbuffer_write(data_config->store_queue, msg, data_config->plugins_count) != 0) {
-			MSG_WARNING(msg_module, "[%u] Unable to write into Data Manager's input queue; skipping data...", data_config->observation_domain_id);
+			MSG_WARNING(msg_module, "[%u] Unable to write into Data Manager input queue; skipping data...", data_config->observation_domain_id);
 			rbuffer_remove_reference(conf->in_queue, index, 1);
 			free(msg);
 			continue;
 		}
 		
-		/* Remove data from queue (without deallocating) */
+		/* Remove data from queue (without memory deallocation) */
 		rbuffer_remove_reference(conf->in_queue, index, 0);
 	}
 
@@ -507,7 +507,7 @@ static void statistics_print_cpu(struct stat_conf *conf, FILE *stat_out_file)
 			continue;
 		}
 		
-		/* parse stat file */
+		/* Parse stat file */
 		snprintf(stat_path, MAX_DIR_LEN, "%s/%s/stat", conf->tasks_dir, entry->d_name);
 		stat = fopen(stat_path, "r");
 		if (!stat) {
@@ -515,7 +515,7 @@ static void statistics_print_cpu(struct stat_conf *conf, FILE *stat_out_file)
 			continue;
 		}
 		
-		/* read thread info */
+		/* Read thread info */
 		uint8_t format_str_len = 62 + sizeof(MAX_DIR_LEN) + 1; // 62 is size of the raw format string, without MAX_DIR_LEN; +1 is null-terminating char
 		char format_str[format_str_len];
 		snprintf(format_str, format_str_len, "%%d (%%%d[^)]) %%c %%*d %%*d %%*d %%*d %%*d %%*u %%*u %%*u %%*u %%*u %%lu %%lu", MAX_DIR_LEN);
@@ -524,7 +524,7 @@ static void statistics_print_cpu(struct stat_conf *conf, FILE *stat_out_file)
 		}
 		fclose(stat);
 		
-		/* Count thread cpu time */
+		/* Count thread CPU time */
 		proc_time = utime + systime;
 		
 		struct stat_thread *thread = statistics_get_thread(conf, tid);
@@ -535,36 +535,36 @@ static void statistics_print_cpu(struct stat_conf *conf, FILE *stat_out_file)
 			}
 		}
 		
-		/* Count thread cpu usage (%) */
+		/* Count thread CPU utilization (%) */
 		if (thread->proc_time && total_cpu - conf->total_cpu > 0) {
 			usage = conf->cpus * (proc_time - thread->proc_time) * 100 / (float) (total_cpu - conf->total_cpu);
 		} else {
 			usage = 0.0;
 		}
 		
-		/* print statistics */
+		/* Print statistics */
 		MSG_INFO(stat_module, "%10d %7c %8.2f %% %15s", tid, state, usage, thread_name);
 		
-		/* update stats */
+		/* Update stats */
 		thread->proc_time = proc_time;
 	}
 
 	MSG_INFO(stat_module, "");
 	closedir(dir);
 
-	// Print to file
+	/* Print to file */
 	if (stat_out_file) {
-		// Add contents here
+		/* Add contents here */
 	}
 	
-	/* update stats */
+	/* Update stats */
 	conf->total_cpu = total_cpu;
 }
 
 /**
  * \brief Print queue usage
  * 
- * @param conf output manager's config
+ * @param conf Output Manager config
  * @param stat_out_file Output file for statistics
  */
 void statistics_print_buffers(struct output_manager_config *conf, FILE *stat_out_file)
@@ -604,7 +604,7 @@ static void *statistics_thread(void* config)
 	struct output_manager_config *conf = (struct output_manager_config *) config;
 	time_t begin = time(NULL), time_now, runtime;
 	
-	/* create statistics config */
+	/* Create statistics config */
 	conf->stats.total_cpu = 0;
 	conf->stats.threads = NULL;
 	conf->stats.cpus = sysconf(_SC_NPROCESSORS_ONLN);
@@ -637,7 +637,7 @@ static void *statistics_thread(void* config)
 				int max_len = strlen(stat_out_file_path) + 1 + 5 + 1;
 				char buf[max_len];
 
-				// snprintf ensures null-termination if (max_len != 0), which is always true
+				/* snprintf ensures null-termination if (max_len != 0), which is always true */
 				snprintf(buf, max_len, "%s.%d", stat_out_file_path, getpid());
 				stat_out_file = fopen(buf, "w");
 			} else {
@@ -646,7 +646,7 @@ static void *statistics_thread(void* config)
 
 			xmlFree(stat_out_file_path);
 
-			// No need to continue tree traversal, because 'statisticsFile' is only node to look for
+			/* No need to continue tree traversal, because 'statisticsFile' is only node to look for */
 			break;
 		}
 
@@ -656,13 +656,13 @@ static void *statistics_thread(void* config)
 	/* Catch SIGUSR1 */
 	signal(SIGUSR1, sig_handler);
 	
-	/* set thread name */
+	/* Set thread name */
 	prctl(PR_SET_NAME, "ipfixcol:stats", 0, 0, 0);
 	
 	while (conf->stat_interval) {
 		sleep(conf->stat_interval);
 		
-		/* killed by output manager*/
+		/* Killed by Output Manager */
 		if (conf->stats.done) {
 			break;
 		}
@@ -676,7 +676,7 @@ static void *statistics_thread(void* config)
 		MSG_INFO(stat_module, "Time: %lu, runtime: %lu", time_now, runtime);
 
 		if (stat_out_file) {
-			rewind(stat_out_file); // Move to beginning of file
+			rewind(stat_out_file); /* Move to beginning of file */
 			fprintf(stat_out_file, "%s=%lu\n", "TIME", time_now);
 			fprintf(stat_out_file, "%s=%lu\n", "RUNTIME", runtime);
 		}
@@ -749,10 +749,10 @@ static void *statistics_thread(void* config)
 			fflush(stat_out_file);
 		}
 		
-		/* print cpu usage by threads */
+		/* Print CPU usage by threads */
 		statistics_print_cpu(&(conf->stats), stat_out_file);
 		
-		/* print buffers usage */
+		/* Print buffer usage */
 		statistics_print_buffers(conf, stat_out_file);
 
 		MSG_INFO(stat_module, "");
@@ -785,12 +785,11 @@ int output_manager_create(configurator *plugins_config, int stat_interval, void 
 	conf->plugins_config = plugins_config;
 	
 	*config = conf;
-	
 	return 0;
 }
 
 /**
- * \brief Start Output Manager's thread(s)
+ * \brief Start Output Manager thread(s)
  * 
  * @return 0 on success
  */
@@ -829,7 +828,7 @@ void output_manager_close(void *config)
 	struct data_manager_config *aux_config = NULL, *tmp = NULL;
 	struct stat_thread *aux_thread = NULL, *tmp_thread = NULL;
 
-	/* Stop Output Manager's thread and free input buffer */
+	/* Stop Output Manager thread and free input buffer */
 	if (manager->running) {
 		rbuffer_write(manager->in_queue, NULL, 1);
 		pthread_join(manager->thread_id, NULL);
@@ -843,6 +842,7 @@ void output_manager_close(void *config)
 		}
 
 		aux_config = manager->data_managers;
+
 		/* Close all data managers */
 		while (aux_config) {
 			tmp = aux_config;

--- a/base/src/output_manager.h
+++ b/base/src/output_manager.h
@@ -84,15 +84,8 @@ struct output_manager_config {
 	pthread_t thread_id;                        /**< Manager's thread ID */
 	pthread_t stat_thread;                      /**< Stat's thread ID */
 	int stat_interval;                          /**< Stat's interval */
-	uint64_t data_records;                      /**< Number of processed data records */
-	uint16_t last_msg_data_records;             /**< Number of data records in last message */
-	uint64_t lost_data_records;                 /**< Number of lost data records */
-	uint32_t first_seq;                         /**< Stream's first sequence number */
-	uint32_t last_seq;                          /**< Sequence number of last packet in stream */
-	uint64_t packets;                           /**< Number of processed packets */
 	struct stat_conf stats;                     /**< Statistics */
 	configurator *plugins_config;               /**< Plugins configurator */
-	
 	pthread_mutex_t in_q_mutex;
 	pthread_cond_t  in_q_cond;
 };

--- a/base/src/preprocessor.c
+++ b/base/src/preprocessor.c
@@ -612,6 +612,10 @@ void preprocessor_parse_msg (void* packet, int len, struct input_info* input_inf
 		/* Add the number of records to both ODID and source sequence numbers (for future check) */
 		msg->input_info->sequence_number += msg->data_records_count;
 		*seqn += msg->data_records_count;
+
+		/* Update other input_info variables */
+		++msg->input_info->packets;
+		msg->input_info->data_records += msg->data_records_count;
 	}
 
 	/* Send data to the first intermediate plugin */

--- a/base/src/preprocessor.c
+++ b/base/src/preprocessor.c
@@ -54,7 +54,6 @@
 static char *msg_module = "preprocessor";
 
 static struct ring_buffer *preprocessor_out_queue = NULL;
-
 static configurator *global_config = NULL;
 
 /* Sequence number counter for each ODID */
@@ -98,7 +97,7 @@ struct odid_info *odid_info_add(uint32_t odid)
 
 	aux_info = calloc(1, sizeof(struct odid_info));
 	if (!aux_info) {
-		MSG_ERROR(msg_module, "Not enough memory (%s:%d)", __FILE__, __LINE__);
+		MSG_ERROR(msg_module, "Memory allocation failed (%s:%d)", __FILE__, __LINE__);
 		return NULL;
 	}
 	aux_info->odid = odid;
@@ -274,23 +273,27 @@ uint32_t preprocessor_compute_crc(struct input_info *input_info)
  * @param[in,out] udp_conf 	UDP template configuration structure to be filled in
  * @return void
  */
-static void preprocessor_udp_init (struct input_info_network *input_info, struct udp_conf *udp_conf) {
+static void preprocessor_udp_init(struct input_info_network *input_info, struct udp_conf *udp_conf)
+{
 	if (input_info->type == SOURCE_TYPE_UDP) {
-		if (((struct input_info_network*) input_info)->template_life_time != NULL) {
-			udp_conf->template_life_time = atoi(((struct input_info_network*) input_info)->template_life_time);
+		if (input_info->template_life_time != NULL) {
+			udp_conf->template_life_time = atoi(((struct input_info_network *) input_info)->template_life_time);
 		} else {
 			udp_conf->template_life_time = TM_UDP_TIMEOUT;
 		}
+
 		if (input_info->template_life_packet != NULL) {
 			udp_conf->template_life_packet = atoi(input_info->template_life_packet);
 		} else {
 			udp_conf->template_life_packet = 0;
 		}
+
 		if (input_info->options_template_life_time != NULL) {
-			udp_conf->options_template_life_time = atoi(((struct input_info_network*) input_info)->options_template_life_time);
+			udp_conf->options_template_life_time = atoi(((struct input_info_network *) input_info)->options_template_life_time);
 		} else {
 			udp_conf->options_template_life_time = TM_UDP_TIMEOUT;
 		}
+
 		if (input_info->options_template_life_packet != NULL) {
 			udp_conf->options_template_life_packet = atoi(input_info->options_template_life_packet);
 		} else {
@@ -311,7 +314,7 @@ static void preprocessor_udp_init (struct input_info_network *input_info, struct
  * \return length of the template
  */
 static int preprocessor_process_one_template(void *tmpl, int max_len, int type, 
-	uint32_t msg_counter, struct input_info *input_info, struct ipfix_template_key *key)
+		uint32_t msg_counter, struct input_info *input_info, struct ipfix_template_key *key)
 {
 	struct ipfix_template_record *template_record;
 	struct ipfix_template *template;
@@ -398,7 +401,7 @@ void fill_metadata(uint8_t *rec, int rec_len, struct ipfix_template *templ, void
 		mdata_max = 75;
 		msg->metadata = calloc(mdata_max, sizeof(struct metadata));
 		if (!msg->metadata) {
-			MSG_ERROR(msg_module, "Not enough memory (%s:%d)", __FILE__, __LINE__);
+			MSG_ERROR(msg_module, "Memory allocation failed (%s:%d)", __FILE__, __LINE__);
 			mdata_max = 0;
 			return;
 		}
@@ -409,7 +412,7 @@ void fill_metadata(uint8_t *rec, int rec_len, struct ipfix_template *templ, void
 		void *new_mdata = realloc(msg->metadata, mdata_max * 2 * sizeof(struct metadata));
 		
 		if (!new_mdata) {
-			MSG_ERROR(msg_module, "Not enough memory (%s:%d)", __FILE__, __LINE__);
+			MSG_ERROR(msg_module, "Memory allocation failed (%s:%d)", __FILE__, __LINE__);
 			return;
 		}
 	
@@ -492,6 +495,7 @@ static uint32_t preprocessor_process_templates(struct ipfix_message *msg)
 		}
 	}
 	mdata_max = 0;
+
 	/* add template to message data_couples */
 	for (i = 0; i < MSG_MAX_DATA_COUPLES && msg->data_couple[i].data_set; i++) {
 		key.tid = ntohs(msg->data_couple[i].data_set->header.flowset_id);
@@ -510,7 +514,7 @@ static uint32_t preprocessor_process_templates(struct ipfix_message *msg)
 					(udp_conf.template_life_packet > 0 && /* life packet should be checked */
 					(uint32_t) (msg_counter - msg->data_couple[i].data_template->last_message) > udp_conf.template_life_packet))) {
 				MSG_WARNING(msg_module, "[%u] Data template with ID %i has expired; using old template...", key.odid,
-				                                               msg->data_couple[i].data_template->template_id);
+						msg->data_couple[i].data_template->template_id);
 			}
 
 			/* compute sequence number and fill metadata */
@@ -541,7 +545,7 @@ static uint32_t preprocessor_process_templates(struct ipfix_message *msg)
  * @param input_info Input informations about source etc.
  * @param source_status Status of source (new, opened, closed)
  */
-void preprocessor_parse_msg (void* packet, int len, struct input_info* input_info, int source_status)
+void preprocessor_parse_msg(void* packet, int len, struct input_info* input_info, int source_status)
 {
 	struct ipfix_message* msg;
 	uint32_t *seqn;
@@ -559,7 +563,7 @@ void preprocessor_parse_msg (void* packet, int len, struct input_info* input_inf
 		odid_info_remove_source(input_info->odid);
 	} else {
 		if (input_info == NULL) {
-			MSG_WARNING(msg_module, "Invalid parameters in function preprocessor_parse_msg()");
+			MSG_WARNING(msg_module, "Invalid parameters in preprocessor_parse_msg()");
 
 			if (packet) {
 				free(packet);
@@ -574,7 +578,7 @@ void preprocessor_parse_msg (void* packet, int len, struct input_info* input_inf
 			return;
 		}
 
-		/* process IPFIX packet and fill up the ipfix_message structure */
+		/* Process IPFIX packet and fill up the ipfix_message structure */
 		msg = message_create_from_mem(packet, len, input_info, source_status);
 		if (!msg) {
 			free(packet);
@@ -596,11 +600,11 @@ void preprocessor_parse_msg (void* packet, int len, struct input_info* input_inf
 		/* If we have a message with data records (the only one that updates sequence number), check the numbers */
 		if (msg->input_info->sequence_number != ntohl(msg->pkt_header->sequence_number) && msg->data_records_count > 0) {
 			if (!skip_seq_err) {
-				MSG_WARNING(msg_module, "[%u] Sequence number error; expected %u, got %u", input_info->odid, msg->input_info->sequence_number , ntohl(msg->pkt_header->sequence_number));
+				MSG_WARNING(msg_module, "[%u] Sequence number error; expected %u, got %u", input_info->odid, msg->input_info->sequence_number, ntohl(msg->pkt_header->sequence_number));
 			}
 
-			/* Add number of seen data records to ODID sequence number to keep up consistency*/
-			*seqn += (ntohl(msg->pkt_header->sequence_number) - msg->input_info->sequence_number);
+			/* Add number of seen data records to ODID sequence number to maintain consistency */
+			*seqn += ntohl(msg->pkt_header->sequence_number) - msg->input_info->sequence_number;
 
 			/* Update sequence number of the source to get in sync again */
 			msg->input_info->sequence_number = ntohl(msg->pkt_header->sequence_number);
@@ -620,7 +624,7 @@ void preprocessor_parse_msg (void* packet, int len, struct input_info* input_inf
 
 	/* Send data to the first intermediate plugin */
 	if (rbuffer_write(preprocessor_out_queue, msg, 1) != 0) {
-		MSG_WARNING(msg_module, "[%u] Unable to write into Data Manager's input queue; skipping data...", input_info->odid);
+		MSG_WARNING(msg_module, "[%u] Unable to write into Data Manager input queue; skipping data...", input_info->odid);
 		message_free(msg);
 		packet = NULL;
 	}


### PR DESCRIPTION
This is a first refactoring round for the data record and loss management within the Output Manager. The old implementation was not able to deal with simultaneous ODIDs, among others. Some corner cases still have to be fixed, but this should already be a major improvement.