### PR TITLE
FastBit storage: data types for enterprise and field IDs are now declared more precisely

### DIFF
--- a/plugins/storage/fastbit/fastbit.cpp
+++ b/plugins/storage/fastbit/fastbit.cpp
@@ -474,7 +474,6 @@ int store_packet(void *config, const struct ipfix_message *ipfix_msg,
 				/* New template was created, it creates new directory if necessary */
 			}
 		}
-
 		
 		/* Should we create new window?  */
 		if (conf->records_window != 0 && rcnt > conf->records_window) {

--- a/plugins/storage/fastbit/fastbit_element.cpp
+++ b/plugins/storage/fastbit/fastbit_element.cpp
@@ -99,7 +99,7 @@ int load_types_from_xml(struct fastbit_config *conf)
 	return 0;
 }
 
-enum store_type get_type_from_xml(struct fastbit_config *conf, unsigned int en, unsigned int id)
+enum store_type get_type_from_xml(struct fastbit_config *conf, uint32_t en, uint16_t id)
 {
 	/* Check whether a type has been determined for the specified element */
 	if ((*conf->elements_types).count(en) == 0 || (*conf->elements_types)[en].count(id) == 0) {
@@ -115,7 +115,7 @@ enum store_type get_type_from_xml(struct fastbit_config *conf, unsigned int en, 
 	return (*conf->elements_types)[en][id];
 }
 
-void element::byte_reorder(uint8_t *dst,uint8_t *src, int srcSize, int dstSize)
+void element::byte_reorder(uint8_t *dst, uint8_t *src, int srcSize, int dstSize)
 {
 	(void) dstSize;
 	int i;
@@ -124,7 +124,7 @@ void element::byte_reorder(uint8_t *dst,uint8_t *src, int srcSize, int dstSize)
 	}
 }
 
-void element::setName(int en, int id, int part)
+void element::setName(uint32_t en, uint16_t id, int part)
 {
 	if (part == -1) { /* default */
 		sprintf( _name, "e%iid%hi", en, id);
@@ -197,7 +197,7 @@ std::string element::get_part_info()
 		"\nEnd Column\n";
 }
 
-el_var_size::el_var_size(int size, int en, int id, uint32_t buf_size)
+el_var_size::el_var_size(int size, uint32_t en, uint16_t id, uint32_t buf_size)
 {
 	(void) buf_size;
 	data = NULL;
@@ -209,7 +209,7 @@ el_var_size::el_var_size(int size, int en, int id, uint32_t buf_size)
 	this->set_type();
 }
 
-uint16_t el_var_size::fill(uint8_t * data)
+uint16_t el_var_size::fill(uint8_t *data)
 {
 	/* Get size of data */
 	if (data[0] < 255) {
@@ -228,7 +228,7 @@ int el_var_size::set_type()
 	return 0;
 }
 
-el_float::el_float(int size, int en, int id, uint32_t buf_size)
+el_float::el_float(int size, uint32_t en, uint16_t id, uint32_t buf_size)
 {
 	_size = size;
 	_filled = 0;
@@ -244,7 +244,7 @@ el_float::el_float(int size, int en, int id, uint32_t buf_size)
 	allocate_buffer(buf_size);
 }
 
-uint16_t el_float::fill(uint8_t * data)
+uint16_t el_float::fill(uint8_t *data)
 {
 	switch(_size) {
 	case 4:
@@ -284,7 +284,7 @@ int el_float::set_type()
 	return 0;
 }
 
-el_text::el_text(int size, int en, int id, uint32_t buf_size)
+el_text::el_text(int size, uint32_t en, uint16_t id, uint32_t buf_size)
 {
 	_size = 1; // this is size for flush function
 	_true_size = size; // this holds true size of string (var of fix size)
@@ -326,7 +326,7 @@ int el_text::append_str(void *data, int size)
 	return 0;
 }
 
-uint16_t el_text::fill(uint8_t * data)
+uint16_t el_text::fill(uint8_t *data)
 {
 	/* Get size of data */
 	if (_var_size) {
@@ -344,7 +344,7 @@ uint16_t el_text::fill(uint8_t * data)
 }
 
 
-el_ipv6::el_ipv6(int size, int en, int id, int part, uint32_t buf_size)
+el_ipv6::el_ipv6(int size, uint32_t en, uint16_t id, int part, uint32_t buf_size)
 {
 	ipv6_value = 0;
 	_size = size;
@@ -361,7 +361,7 @@ el_ipv6::el_ipv6(int size, int en, int id, int part, uint32_t buf_size)
 	allocate_buffer(buf_size);
 }
 
-uint16_t el_ipv6::fill(uint8_t * data)
+uint16_t el_ipv6::fill(uint8_t *data)
 {
 	/* ulong */
 	ipv6_value = be64toh(*((uint64_t*) data));
@@ -376,7 +376,7 @@ int el_ipv6::set_type()
 	return 0;
 }
 
-el_blob::el_blob(int size, int en, int id, uint32_t buf_size):
+el_blob::el_blob(int size, uint32_t en, uint16_t id, uint32_t buf_size):
 	_var_size(false), _true_size(size), _sp_buffer(NULL)
 {
 	/* Set variables defined in parent */
@@ -411,7 +411,7 @@ el_blob::el_blob(int size, int en, int id, uint32_t buf_size):
 	_sp_buffer_offset = 8; /* 8 byte numbers are used to record offset */
 }
 
-uint16_t el_blob::fill(uint8_t * data)
+uint16_t el_blob::fill(uint8_t *data)
 {
 	uint8_t _offset = 0;
 
@@ -500,7 +500,7 @@ el_blob::~el_blob()
 	free(_sp_buffer);
 }
 
-el_uint::el_uint(int size, int en, int id, uint32_t buf_size)
+el_uint::el_uint(int size, uint32_t en, uint16_t id, uint32_t buf_size)
 {
 	_real_size = size;
 	_size = 0;
@@ -518,7 +518,7 @@ el_uint::el_uint(int size, int en, int id, uint32_t buf_size)
 }
 
 
-uint16_t el_uint::fill(uint8_t * data) {
+uint16_t el_uint::fill(uint8_t *data) {
 	uint_value.ulong = 0;
 	switch(_real_size) {
 	case 1:
@@ -632,7 +632,7 @@ int el_sint::set_type()
 	return 0;
 }
 
-el_sint::el_sint(int size , int en, int id, uint32_t buf_size)
+el_sint::el_sint(int size, uint32_t en, uint16_t id, uint32_t buf_size)
 {
 	_real_size = size;
 	_size = 0;
@@ -649,7 +649,7 @@ el_sint::el_sint(int size , int en, int id, uint32_t buf_size)
 	allocate_buffer(buf_size);
 }
 
-el_unknown::el_unknown(int size, int en, int id, int part, uint32_t buf_size)
+el_unknown::el_unknown(int size, uint32_t en, uint16_t id, int part, uint32_t buf_size)
 {
 	(void) en;
 	(void) id;
@@ -682,7 +682,7 @@ int el_unknown::flush(std::string path)
 	return 0;
 }
 
-uint16_t el_unknown::fill(uint8_t * data)
+uint16_t el_unknown::fill(uint8_t *data)
 {
 	/* Get real size of the data */
 	if (_var_size) {

--- a/plugins/storage/fastbit/fastbit_element.h
+++ b/plugins/storage/fastbit/fastbit_element.h
@@ -82,7 +82,7 @@ int load_types_from_xml(struct fastbit_config *conf);
  * @param id ID of information element
  * @return element type
  */
-enum store_type get_type_from_xml(struct fastbit_config *conf,unsigned int en,unsigned int id);
+enum store_type get_type_from_xml(struct fastbit_config *conf, uint32_t en, uint16_t id);
 
 /**
  * \brief Class wrapper for information elements
@@ -118,7 +118,7 @@ protected:
 	 * @param id ID of information element
 	 * @param part Number of part (used for IPv6)
 	 */
-	void setName(int en, int id, int part=-1);
+	void setName(uint32_t en, uint16_t id, int part = -1);
 
 	/**
 	 * \brief Copy data and change byte order
@@ -167,7 +167,7 @@ public:
 	 * @param data pointer to input data (usualy ipfix element)
 	 * @return size of the element read from the data
 	 */
-	virtual uint16_t fill(uint8_t * data) = 0;
+	virtual uint16_t fill(uint8_t *data) = 0;
 
 	/**
 	 * \brief Flush buffer content to file
@@ -189,7 +189,7 @@ class el_var_size : public element
 {
 public:
 	void *data;
-	el_var_size(int size = 0, int en = 0, int id = 0, uint32_t buf_size = RESERVED_SPACE);
+	el_var_size(int size = 0, uint32_t en = 0, uint16_t id = 0, uint32_t buf_size = RESERVED_SPACE);
 	/* core methods */
 	/**
 	 * \brief fill internal element value according to given data
@@ -202,7 +202,7 @@ public:
 	 * @return 0 on succes
 	 * @return 1 on failure
 	 */
-	virtual uint16_t fill(uint8_t * data);
+	virtual uint16_t fill(uint8_t *data);
 
 protected:
 	int set_type();
@@ -219,7 +219,7 @@ class el_float : public element
 {
 public:
 	float_u float_value;
-	el_float(int size = 1, int en = 0, int id = 0, uint32_t buf_size = RESERVED_SPACE);
+	el_float(int size = 1, uint32_t en = 0, uint16_t id = 0, uint32_t buf_size = RESERVED_SPACE);
 	/* core methods */
 	/**
 	 * \brief fill internal element value according to given data
@@ -232,7 +232,7 @@ public:
 	 * @return 0 on succes 
 	 * @return 1 on failure
 	 */
-	virtual uint16_t fill(uint8_t * data);
+	virtual uint16_t fill(uint8_t *data);
 
 protected:
 	int set_type();
@@ -245,9 +245,9 @@ private:
 	uint16_t _true_size;
 	uint8_t _offset;
 public:
-	el_text(int size = 1, int en = 0, int id = 0, uint32_t buf_size = RESERVED_SPACE);
+	el_text(int size = 1, uint32_t en = 0, uint16_t id = 0, uint32_t buf_size = RESERVED_SPACE);
 
-	virtual uint16_t fill(uint8_t * data);
+	virtual uint16_t fill(uint8_t *data);
 
 protected:
 	int set_type() {
@@ -269,7 +269,7 @@ class el_ipv6 : public element
 {
 public:
 	uint64_t ipv6_value;
-	el_ipv6(int size = 1, int en = 0, int id = 0,  int part = 0, uint32_t buf_size = RESERVED_SPACE);
+	el_ipv6(int size = 1, uint32_t en = 0, uint16_t id = 0, int part = 0, uint32_t buf_size = RESERVED_SPACE);
 	/* core methods */
 	/**
 	 * \brief fill internal element value according to given data
@@ -282,7 +282,7 @@ public:
 	 * @return 0 on succes
 	 * @return 1 on failure
 	 */
-	virtual uint16_t fill(uint8_t * data);
+	virtual uint16_t fill(uint8_t *data);
 
 protected:
 	int set_type();
@@ -291,8 +291,8 @@ protected:
 class el_blob : public element
 {
 public:
-	el_blob(int size = 1, int en = 0, int id = 0, uint32_t buf_size = RESERVED_SPACE);
-	virtual uint16_t fill(uint8_t * data);
+	el_blob(int size = 1, uint32_t en = 0, uint16_t id = 0, uint32_t buf_size = RESERVED_SPACE);
+	virtual uint16_t fill(uint8_t *data);
 	virtual ~el_blob();
 
 	/**
@@ -331,7 +331,7 @@ typedef union uinteger_union
 class el_uint : public element
 {
 public:
-	el_uint(int size = 1, int en = 0, int id = 0, uint32_t buf_size = RESERVED_SPACE);
+	el_uint(int size = 1, uint32_t en = 0, uint16_t id = 0, uint32_t buf_size = RESERVED_SPACE);
 	/* core methods */
 	/**
 	 * \brief fill internal element value according to given data
@@ -344,7 +344,7 @@ public:
 	 * @return 0 on succes
 	 * @return 1 on failure
 	 */
-	virtual uint16_t fill(uint8_t * data);
+	virtual uint16_t fill(uint8_t *data);
 
 protected:
 	uint_u uint_value;
@@ -356,7 +356,7 @@ protected:
 class el_sint : public el_uint
 {
 public:
-	el_sint(int size = 1, int en = 0, int id = 0, uint32_t buf_size = RESERVED_SPACE);
+	el_sint(int size = 1, uint32_t en = 0, uint16_t id = 0, uint32_t buf_size = RESERVED_SPACE);
 
 protected:
 	int set_type();
@@ -387,7 +387,7 @@ protected:
 	int append(void *data);
 
 public:
-	el_unknown(int size = 0, int en = 0, int id = 0,  int part = 0, uint32_t buf_size = 0);
+	el_unknown(int size = 0, uint32_t en = 0, uint16_t id = 0, int part = 0, uint32_t buf_size = 0);
 
 	/* core methods */
 	/**
@@ -400,7 +400,7 @@ public:
 	 * @param data pointer to input data (usualy ipfix element)
 	 * @return size of the element read from the data
 	 */
-	virtual uint16_t fill(uint8_t * data);
+	virtual uint16_t fill(uint8_t *data);
 
 	/**
 	 * \brief Flush buffer content to file

--- a/plugins/storage/fastbit/fastbit_table.cpp
+++ b/plugins/storage/fastbit/fastbit_table.cpp
@@ -68,7 +68,7 @@ uint64_t get_rows_from_part(const char *part_path)
 	return rows;
 }
 
-template_table::template_table(int template_id, uint32_t buff_size): _rows_count(0)
+template_table::template_table(uint16_t template_id, uint32_t buff_size): _rows_count(0)
 {
 	_template_id = template_id;
 	sprintf(_name, "%u",template_id);
@@ -191,7 +191,7 @@ int template_table::dir_check(std::string path, bool new_dir)
 	return 0;
 }
 
-int template_table::store(ipfix_data_set * data_set, std::string path, bool new_dir)
+int template_table::store(ipfix_data_set *data_set, std::string path, bool new_dir)
 {
 	uint8_t *data = data_set->records;
 	uint16_t element_size = 0;
@@ -283,7 +283,7 @@ void template_table::flush(std::string path)
 	}
 }
 
-int template_table::parse_template(struct ipfix_template * tmp,struct fastbit_config * config)
+int template_table::parse_template(struct ipfix_template *tmp,struct fastbit_config *config)
 {
 	int i;
 	uint32_t en = 0; /* enterprise number (0 = IANA elements) */

--- a/plugins/storage/fastbit/fastbit_table.h
+++ b/plugins/storage/fastbit/fastbit_table.h
@@ -89,11 +89,11 @@ public:
 	std::vector<element *> elements;
 	std::vector<element *>::iterator el_it;
 
-	template_table(int template_id, uint32_t buff_size);
+	template_table(uint16_t template_id, uint32_t buff_size);
 	int rows() {return _rows_count;}
 	void rows(int rows_count) {_rows_count = rows_count;}
 	std::string name(){return std::string(_name);}
-	int parse_template(struct ipfix_template * tmp,struct fastbit_config *config);
+	int parse_template(struct ipfix_template *tmp,struct fastbit_config *config);
 
 	/**
 	 * \brief parse data_set and store it's data in memory
@@ -105,7 +105,7 @@ public:
 	 * @param path path to direcotry where should be data flushed
 	 * @param new_dir does the path lead to new directory?
 	 */
-	int store(ipfix_data_set * data_set, std::string path, bool new_dir);
+	int store(ipfix_data_set *data_set, std::string path, bool new_dir);
 
 	int update_part(std::string path);
 


### PR DESCRIPTION
Although caused by another bug (fixed in CESNET/devel already), we have seen data with enterprise ID '-1'. To avoid such issues, enterprise and field IDs are now properly declared using `uint_t` data structures instead of regular integers.