### PR TITLE
fbitmerge: refactored to use std::string instead of c_str()

### DIFF
--- a/tools/fbitmerge/src/fbitmerge.h
+++ b/tools/fbitmerge/src/fbitmerge.h
@@ -90,17 +90,16 @@ enum size {
 
 void usage();
 
-int merge_all(const char *workDir, uint16_t key, char *prefix);
+int merge_all(std::string workDir, uint16_t key, std::string prefix);
 
-int merge_couple(const char *srcDir, const char *dstDir, const char *workDir);
+int merge_couple(std::string srcDir, std::string dstDir, std::string workDir);
 
-int merge_dirs(const char *srcDir, const char *dstDir);
+int merge_dirs(std::string srcDir, std::string dstDir);
 
-void merge_flowStats(const char *first, const char *second);
+void merge_flowStats(std::string first, std::string second);
 
-int move_prefixed_dirs(const char *baseDir, const char *workDir, char *prefix, int key);
+int move_prefixed_dirs(std::string baseDir, std::string workDir, std::string prefix, int key);
 
-void remove_folder_tree(const char *dirname);
-
+void remove_folder_tree(std::string dirname);
 
 #endif /* FBITMERGE_H_ */


### PR DESCRIPTION
A little background on this code change: we were encountering some strange behavior of fbitmerge that caused the values in `std::map<uint32_t, char *> dirMap` (fbitmerge.cpp:564) to become corrupted at some point in time. This issue occurred every day in our daylong datasets, causing the merge process to fail. This pull request resolves this issue and should not affect functionality.