### PR TITLE
Input plugin logging consistency fixes

### DIFF
--- a/base/src/input/sctp/sctp_input.c
+++ b/base/src/input/sctp/sctp_input.c
@@ -708,7 +708,7 @@ wait_for_data:
 	}
 
 	if (msg_length < IPFIX_HEADER_LENGTH) {
-		MSG_ERROR(msg_module, "Packet header is incomplete; skipping message...", msg_length);
+		MSG_WARNING(msg_module, "Packet header is incomplete; skipping message...", msg_length);
 		return INPUT_INTR;
 	}
 
@@ -721,11 +721,11 @@ wait_for_data:
 	}
 
 	/* Check if lengths are the same */
-	if (msg_length < htons(((struct ipfix_header *)*packet)->length)) {
-		MSG_ERROR(msg_module, "Packet is incomplete; skipping message...");
+	if (msg_length < htons(((struct ipfix_header *) *packet)->length)) {
+		MSG_WARNING(msg_module, "Packet is incomplete; skipping message...");
 		return INPUT_INTR;
-	} else if (msg_length > htons(((struct ipfix_header *)*packet)->length)) {
-		msg_length = htons(((struct ipfix_header *)*packet)->length);
+	} else if (msg_length > htons(((struct ipfix_header *) *packet)->length)) {
+		msg_length = htons(((struct ipfix_header *) *packet)->length);
 	}
 
 #if 0

--- a/base/src/input/sctp/sctp_input.c
+++ b/base/src/input/sctp/sctp_input.c
@@ -158,7 +158,7 @@ void *listen_worker(void *data) {
 		/* input_info - fill out information about input */
 		node = (struct input_info_node *) calloc(1, sizeof(*node));
 		if (!node) {
-			MSG_ERROR(msg_module, "Not enough memory (%s:%d)", __FILE__, __LINE__);
+			MSG_ERROR(msg_module, "Memory allocation failed (%s:%d)", __FILE__, __LINE__);
 			goto err_assoc;
 		}
 
@@ -254,7 +254,7 @@ int input_init(char *params, void **config)
 	/* allocate memory for config structure */
 	conf = (struct sctp_config *) malloc(sizeof(*conf));
 	if (!conf) {
-		MSG_ERROR(msg_module, "Not enough memory (%s:%d)", __FILE__, __LINE__);
+		MSG_ERROR(msg_module, "Memory allocation failed (%s:%d)", __FILE__, __LINE__);
 		return -1;
 	}
 	memset(conf, 0, sizeof(*conf));
@@ -264,7 +264,7 @@ int input_init(char *params, void **config)
 	sockaddr6_listen = (struct sockaddr_in6 **) 
 	malloc(DEFAULT_NUMBER_OF_ADDRESSES * sizeof(*(sockaddr6_listen)));
 	if (sockaddr6_listen == NULL) {
-		MSG_ERROR(msg_module, "Not enough memory (%s:%d)", __FILE__, __LINE__);
+		MSG_ERROR(msg_module, "Memory allocation failed (%s:%d)", __FILE__, __LINE__);
 		goto err_sockaddr6;
 	}
 	memset(sockaddr6_listen, 0, sizeof(DEFAULT_NUMBER_OF_ADDRESSES * sizeof(*(sockaddr6_listen))));
@@ -274,7 +274,7 @@ int input_init(char *params, void **config)
 	 * sctp_bindx() for multi-homing support */
 	sockaddr_listen = (struct sockaddr_in **) calloc(DEFAULT_NUMBER_OF_ADDRESSES, sizeof(*(sockaddr_listen)));
 	if (sockaddr_listen == NULL) {
-		MSG_ERROR(msg_module, "Not enough memory (%s:%d)", __FILE__, __LINE__);
+		MSG_ERROR(msg_module, "Memory allocation failed (%s:%d)", __FILE__, __LINE__);
 		goto err_sockaddr;
 	}
 	sockaddr_listen_max = DEFAULT_NUMBER_OF_ADDRESSES;
@@ -324,7 +324,7 @@ int input_init(char *params, void **config)
 				/* add new IPv4 address */
 				sockaddr = (struct sockaddr_in *) malloc(sizeof(*sockaddr));
 				if (!sockaddr) {
-					MSG_ERROR(msg_module, "Not enough memory (%s:%d)", __FILE__, __LINE__);
+					MSG_ERROR(msg_module, "Memory allocation failed (%s:%d)", __FILE__, __LINE__);
 					goto err_sockaddr_case;
 				}
 				memset(sockaddr, 0, sizeof(*sockaddr));
@@ -378,7 +378,7 @@ err_sockaddr_case:
 				/* add new IPv6 address */
 				sockaddr6 = (struct sockaddr_in6 *) malloc(sizeof(*sockaddr6));
 				if (!sockaddr6) {
-					MSG_ERROR(msg_module, "Not enough memory (%s:%d)", __FILE__, __LINE__);
+					MSG_ERROR(msg_module, "Memory allocation failed (%s:%d)", __FILE__, __LINE__);
 					goto err_sockaddr6_case;
 				}
 				memset(sockaddr6, 0, sizeof(*sockaddr6));
@@ -457,7 +457,7 @@ err_sockaddr6_case:
 	if ((sockaddr6_listen_counter == 0) && (sockaddr_listen_counter == 0)) {
 		sockaddr6 = (struct sockaddr_in6 *) calloc(1, sizeof(*sockaddr6));
 		if (!sockaddr6) {
-			MSG_ERROR(msg_module, "Not enough memory (%s:%d)", __FILE__, __LINE__);
+			MSG_ERROR(msg_module, "Memory allocation failed (%s:%d)", __FILE__, __LINE__);
 			goto err;
 		}
 
@@ -691,7 +691,7 @@ wait_for_data:
 		/* TODO - we can check how big the message is from its header */
 		*packet = (char *) malloc(MSG_MAX_LENGTH);
 		if (*packet == NULL) {
-			MSG_ERROR(msg_module, "Not enough memory (%s:%d)", __FILE__, __LINE__);
+			MSG_ERROR(msg_module, "Memory allocation failed (%s:%d)", __FILE__, __LINE__);
 			ret = INPUT_ERROR;
 			goto out;
 		}

--- a/base/src/input/tcp/tcp_input.c
+++ b/base/src/input/tcp/tcp_input.c
@@ -380,7 +380,7 @@ void *input_listen(void *config)
 
 			if (conf->ssl_list[i] != ssl) {
 				/* limit reached. no space for new SSL structure */
-				MSG_WARNING(msg_module, "Limit on the number of TLS connections reached; tearing down this connection...");
+				MSG_WARNING(msg_module, "Reached limit on the number of TLS connections; tearing down this connection...");
 				/* cleanup */
 				input_listen_tls_cleanup(conf, &maid);
 				continue;
@@ -396,7 +396,7 @@ void *input_listen(void *config)
 
 		/* copy socket address to config structure */
 		if (!add_sock_address(conf, address, new_sock)) {
-			MSG_ERROR(msg_module, "Cannot store another socket address!");
+			MSG_ERROR(msg_module, "Cannot store another socket address");
 			break;
 		}
 
@@ -729,7 +729,7 @@ int input_init(char *params, void **config)
 		
 		ssl_list = (SSL **) malloc(sizeof(SSL *) * DEFAULT_SIZE_SSL_LIST);
 		if (ssl_list == NULL) {
-			MSG_ERROR(msg_module, "Not enough memory (%s:%d)", __FILE__, __LINE__);
+			MSG_ERROR(msg_module, "Memory allocation failed (%s:%d)", __FILE__, __LINE__);
 			retval = 1;
 			goto out;
 		}
@@ -923,6 +923,7 @@ int get_packet(void *config, struct input_info **info, char **packet, int *sourc
 				break;
 			}
 		}
+
 		length = SSL_read(ssl, *packet, IPFIX_HEADER_LENGTH);
 		if (length < 0) {
 			/* read operation was not successful */
@@ -930,6 +931,7 @@ int get_packet(void *config, struct input_info **info, char **packet, int *sourc
 				if (errno == EINTR) {
 					return INPUT_INTR;
 				}
+
 				MSG_ERROR(msg_module, "Failed to receive IPFIX packet header: %s", strerror(errno));
 				return INPUT_ERROR;
 			}
@@ -942,6 +944,7 @@ int get_packet(void *config, struct input_info **info, char **packet, int *sourc
 			if (errno == EINTR) {
 				return INPUT_INTR;
 			}
+
 			MSG_ERROR(msg_module, "Failed to receive IPFIX packet header: %s", strerror(errno));
 			return INPUT_ERROR;
 		}

--- a/base/src/input/tcp/tcp_input.c
+++ b/base/src/input/tcp/tcp_input.c
@@ -957,7 +957,7 @@ int get_packet(void *config, struct input_info **info, char **packet, int *sourc
 		if (packet_length > BUFF_LEN) {
 			*packet = realloc(*packet, packet_length);
 			if (*packet == NULL) {
-				MSG_ERROR(msg_module, "Packet too big and realloc failed: %s", strerror(errno));
+				MSG_WARNING(msg_module, "Packet too big and realloc failed: %s", strerror(errno));
 				return INPUT_ERROR;
 			}
 		}
@@ -972,11 +972,11 @@ int get_packet(void *config, struct input_info **info, char **packet, int *sourc
 			if (errno == EINTR) {
 				return INPUT_INTR;
 			}
-			MSG_WARNING(msg_module, "Failed to receive IPFIX packet: %s", strerror(errno));
-			return INPUT_ERROR;
 
+			MSG_ERROR(msg_module, "Failed to receive IPFIX packet: %s", strerror(errno));
+			return INPUT_ERROR;
 		} else if (length < packet_length - IPFIX_HEADER_LENGTH) {
-			MSG_ERROR(msg_module, "Read IPFIX data is too short (%i): %s", length, strerror(errno));
+			MSG_WARNING(msg_module, "Read IPFIX data is too short (%i): %s", length, strerror(errno));
 		}
 
 		length += IPFIX_HEADER_LENGTH;
@@ -997,7 +997,7 @@ int get_packet(void *config, struct input_info **info, char **packet, int *sourc
 			length = htons(((struct ipfix_header*)*packet)->length);
 		}
 	} else if (length != 0) {
-		MSG_ERROR(msg_module, "Packet header is incomplete; closing connection...");
+		MSG_WARNING(msg_module, "Packet header is incomplete; closing connection...");
 
 		/* this will close the connection */
 		length = 0;
@@ -1062,6 +1062,7 @@ int get_packet(void *config, struct input_info **info, char **packet, int *sourc
 		} else {
 			inet_ntop(AF_INET6, &conf->sock_addresses[sock]->sin6_addr, src_addr, INET6_ADDRSTRLEN);
 		}
+
 		(*info)->status = SOURCE_STATUS_CLOSED;
 		*source_status = SOURCE_STATUS_CLOSED;
 

--- a/base/src/input/udp/udp_input.c
+++ b/base/src/input/udp/udp_input.c
@@ -384,7 +384,7 @@ int get_packet(void *config, struct input_info **info, char **packet, int *sourc
 	}
 
 	if (length < IPFIX_HEADER_LENGTH) {
-		MSG_ERROR(msg_module, "Packet header is incomplete; skipping message...");
+		MSG_WARNING(msg_module, "Packet header is incomplete; skipping message...");
 		return INPUT_INTR;
 	}
 

--- a/base/src/ipfixcol.c
+++ b/base/src/ipfixcol.c
@@ -365,8 +365,12 @@ int main (int argc, char* argv[])
 	while (!terminating) {
 		/* get data to process */
 		if ((get_retval = config->input.get(config->input.config, &input_info, &packet, &source_status)) < 0) {
-			if ((!reconf && !terminating) || get_retval != INPUT_INTR) { /* if interrupted and closing, it's ok */
-				MSG_WARNING(msg_module, "[%d] Could not get IPFIX data", config->proc_id);
+			if ((!reconf && !terminating) || get_retval != INPUT_INTR) {
+				/* If interrupted and closing, it's OK */
+				/* We don't print warnings or errors here, since we leave that responsibility
+				 * to the respective input plugin.
+				 */
+				// MSG_WARNING(msg_module, "[%d] Could not get IPFIX data", config->proc_id);
 			}
 			
 			if (reconf) {
@@ -431,6 +435,7 @@ cleanup:
 			pid = wait(NULL);
 			MSG_NOTICE(msg_module, "[%d] Collector child process '%d' terminated", config->proc_id, pid);
 		}
+
 		MSG_NOTICE(msg_module, "[%d] Closing collector", config->proc_id);
 	}
 


### PR DESCRIPTION
Avoids duplicate logging, especially upon receiving non-NetFlow and non-IPFIX traffic on the listening ports.