### PR TITLE
Sanity checks in PDU conversion code

### DIFF
--- a/base/src/input/sctp/convert.h
+++ b/base/src/input/sctp/convert.h
@@ -64,10 +64,11 @@ int convert_init(int in_plugin, int len);
  *
  * \param[out] packet Flow information data in the form of IPFIX packet
  * \param[in] len Length of packet
+ * \param[in] max_len Amount of memory allocated for packet
  * \param[in] input_info Information structure storing data needed for refreshing templates
  * \return 0 on success, a negative value otherwise
  */
-int convert_packet(char **packet, ssize_t *len, char *input_info);
+int convert_packet(char **packet, ssize_t *len, uint16_t max_len, char *input_info);
 
 /**
  * \brief Reallocate memory for templates

--- a/base/src/input/sctp/convert.h
+++ b/base/src/input/sctp/convert.h
@@ -46,6 +46,8 @@ enum {
 	SCTP_PLUGIN
 };
 
+#define CONVERSION_ERROR -1
+
 /**
  * \brief Prepare static variables used for inserting template and data sets
  *

--- a/base/src/input/sctp/sctp_input.c
+++ b/base/src/input/sctp/sctp_input.c
@@ -68,8 +68,8 @@
 /* API version constant */
 IPFIXCOL_API_VERSION;
 
-#define DEFAULT_LISTEN_PORT_UNSECURE 4739
-#define DEFAULT_LISTEN_PORT_SECURE   4740   /* listen port when used with DTLS */
+#define DEFAULT_LISTEN_PORT        4739
+#define DEFAULT_LISTEN_PORT_DLTS   4740   /* listen port when used with DTLS */
 
 /* maximum input/output streams per association */
 #define INSTREAMS_PER_SOCKET         20
@@ -471,7 +471,7 @@ err_sockaddr6_case:
 
 	/* use default listen port if not specified otherwise */
 	if (conf->listen_port == 0) {
-		conf->listen_port = DEFAULT_LISTEN_PORT_UNSECURE;
+		conf->listen_port = DEFAULT_LISTEN_PORT;
 	}
 
 	/* same port for every IPv4 address */

--- a/base/src/input/sctp/sctp_input.c
+++ b/base/src/input/sctp/sctp_input.c
@@ -714,7 +714,7 @@ wait_for_data:
 
 	/* Convert packet from Netflow v5/v9/sflow to IPFIX format */
 	if (htons(((struct ipfix_header *) (*packet))->version) != IPFIX_VERSION) {
-		if (convert_packet(packet, &msg_length, NULL) != 0) {
+		if (convert_packet(packet, &msg_length, MSG_MAX_LENGTH, NULL) != 0) {
 			MSG_WARNING(msg_module, "Message conversion error; skipping message...");
 			return INPUT_INTR;
 		}

--- a/base/src/input/tcp/convert.h
+++ b/base/src/input/tcp/convert.h
@@ -64,10 +64,11 @@ int convert_init(int in_plugin, int len);
  *
  * \param[out] packet Flow information data in the form of IPFIX packet
  * \param[in] len Length of packet
+ * \param[in] max_len Amount of memory allocated for packet
  * \param[in] input_info Information structure storing data needed for refreshing templates
  * \return 0 on success, a negative value otherwise
  */
-int convert_packet(char **packet, ssize_t *len, char *input_info);
+int convert_packet(char **packet, ssize_t *len, uint16_t max_len, char *input_info);
 
 /**
  * \brief Reallocate memory for templates

--- a/base/src/input/tcp/convert.h
+++ b/base/src/input/tcp/convert.h
@@ -46,6 +46,8 @@ enum {
 	SCTP_PLUGIN
 };
 
+#define CONVERSION_ERROR -1
+
 /**
  * \brief Prepare static variables used for inserting template and data sets
  *

--- a/base/src/input/tcp/tcp_input.c
+++ b/base/src/input/tcp/tcp_input.c
@@ -860,7 +860,8 @@ int get_packet(void *config, struct input_info **info, char **packet, int *sourc
 {
 	/* temporary socket set */
 	fd_set tmp_set;
-	ssize_t length = 0, packet_length;
+	ssize_t len = 0, packet_len;
+	uint16_t max_msg_len = BUFF_LEN * sizeof(char);
 	struct timeval tv;
 	char src_addr[INET6_ADDRSTRLEN];
 	struct sockaddr_in6 *address;
@@ -874,7 +875,7 @@ int get_packet(void *config, struct input_info **info, char **packet, int *sourc
 
 	/* allocate memory for packet, if needed */
 	if (*packet == NULL) {
-		*packet = malloc(BUFF_LEN * sizeof(char));
+		*packet = malloc(max_msg_len);
 		if (*packet == NULL) {
 			MSG_ERROR(msg_module, "Cannot allocate memory for the packet, malloc failed: %s", strerror(errno));
 		}
@@ -923,10 +924,11 @@ int get_packet(void *config, struct input_info **info, char **packet, int *sourc
 				break;
 			}
 		}
-		length = SSL_read(ssl, *packet, IPFIX_HEADER_LENGTH);
-		if (length < 0) {
+
+		len = SSL_read(ssl, *packet, IPFIX_HEADER_LENGTH);
+		if (len < 0) {
 			/* read operation was not successful */
-			if (SSL_get_error(ssl, length) == SSL_ERROR_SYSCALL) {
+			if (SSL_get_error(ssl, len) == SSL_ERROR_SYSCALL) {
 				if (errno == EINTR) {
 					return INPUT_INTR;
 				}
@@ -937,8 +939,8 @@ int get_packet(void *config, struct input_info **info, char **packet, int *sourc
 	} else {
 #endif
 		/* receive without TLS */
-		length = recv(sock, *packet, IPFIX_HEADER_LENGTH, MSG_WAITALL);
-		if (length == -1) {
+		len = recv(sock, *packet, IPFIX_HEADER_LENGTH, MSG_WAITALL);
+		if (len == -1) {
 			if (errno == EINTR) {
 				return INPUT_INTR;
 			}
@@ -949,13 +951,13 @@ int get_packet(void *config, struct input_info **info, char **packet, int *sourc
 	}
 #endif
 	
-	if (length >= IPFIX_HEADER_LENGTH) { /* header received */
+	if (len >= IPFIX_HEADER_LENGTH) { /* header received */
 		/* get packet total length */
-		packet_length = ntohs(((struct ipfix_header *) *packet)->length);
+		packet_len = ntohs(((struct ipfix_header *) *packet)->length);
 
 		/* check whether buffer is big enough */
-		if (packet_length > BUFF_LEN) {
-			*packet = realloc(*packet, packet_length);
+		if (packet_len > BUFF_LEN) {
+			*packet = realloc(*packet, packet_len);
 			if (*packet == NULL) {
 				MSG_ERROR(msg_module, "Packet too big and realloc failed: %s", strerror(errno));
 				return INPUT_ERROR;
@@ -964,43 +966,43 @@ int get_packet(void *config, struct input_info **info, char **packet, int *sourc
 
 		/* receive the rest of the ipfix packet */
 		if (ntohs(((struct ipfix_header *) *packet)->version) == IPFIX_VERSION) {
-			length = recv(sock, (*packet) + IPFIX_HEADER_LENGTH, packet_length - IPFIX_HEADER_LENGTH, MSG_WAITALL);
+			len = recv(sock, (*packet) + IPFIX_HEADER_LENGTH, packet_len - IPFIX_HEADER_LENGTH, MSG_WAITALL);
 		} else {
-			length = recv(sock, (*packet) + IPFIX_HEADER_LENGTH, BUFF_LEN - IPFIX_HEADER_LENGTH, 0);
+			len = recv(sock, (*packet) + IPFIX_HEADER_LENGTH, BUFF_LEN - IPFIX_HEADER_LENGTH, 0);
 		}
-		if (length == -1) {
+
+		if (len == -1) {
 			if (errno == EINTR) {
 				return INPUT_INTR;
 			}
 			MSG_WARNING(msg_module, "Failed to receive IPFIX packet: %s", strerror(errno));
 			return INPUT_ERROR;
 
-		} else if (length < packet_length - IPFIX_HEADER_LENGTH) {
-			MSG_ERROR(msg_module, "Read IPFIX data is too short (%i): %s", length, strerror(errno));
+		} else if (len < packet_len - IPFIX_HEADER_LENGTH) {
+			MSG_ERROR(msg_module, "Read IPFIX data is too short (%i): %s", len, strerror(errno));
 		}
 
-		length += IPFIX_HEADER_LENGTH;
+		len += IPFIX_HEADER_LENGTH;
 
 		/* Convert packet from Netflow v5/v9/sflow to IPFIX format */
 		if (htons(((struct ipfix_header *) (*packet))->version) != IPFIX_VERSION) {
-			if (convert_packet(packet, &length, NULL) != 0) {
+			if (convert_packet(packet, &len, max_msg_len, NULL) != 0) {
 				MSG_WARNING(msg_module, "Message conversion error; skipping message...");
 				return INPUT_INTR;
 			}
 		}
 
 		/* Check if lengths are the same */
-		if (length < htons(((struct ipfix_header *)*packet)->length)) {
-			MSG_DEBUG(msg_module, "length = %d, header->length = %d", length, htons(((struct ipfix_header *)*packet)->length));
+		if (len < htons(((struct ipfix_header *) *packet)->length)) {
 			return INPUT_INTR;
-		} else if (length >  htons(((struct ipfix_header *)*packet)->length)) {
-			length = htons(((struct ipfix_header*)*packet)->length);
+		} else if (len > htons(((struct ipfix_header *) *packet)->length)) {
+			len = htons(((struct ipfix_header*) *packet)->length);
 		}
-	} else if (length != 0) {
+	} else if (len != 0) {
 		MSG_ERROR(msg_module, "Packet header is incomplete; closing connection...");
 
 		/* this will close the connection */
-		length = 0;
+		len = 0;
 	}
 
 	/* get peer address from configuration */
@@ -1042,7 +1044,7 @@ int get_packet(void *config, struct input_info **info, char **packet, int *sourc
 	*info = (struct input_info*) &info_list->info;
 
 	/* check whether socket closed */
-	if (length == 0) {
+	if (len == 0) {
 #ifdef TLS_SUPPORT
 		if (conf->tls) {
 			if (SSL_get_shutdown(ssl) != SSL_RECEIVED_SHUTDOWN) {
@@ -1077,7 +1079,7 @@ int get_packet(void *config, struct input_info **info, char **packet, int *sourc
 		return INPUT_CLOSED;
 	}
 
-	return length;
+	return len;
 }
 
 /**

--- a/base/src/input/udp/convert.h
+++ b/base/src/input/udp/convert.h
@@ -64,10 +64,11 @@ int convert_init(int in_plugin, int len);
  *
  * \param[out] packet Flow information data in the form of IPFIX packet
  * \param[in] len Length of packet
+ * \param[in] max_len Amount of memory allocated for packet
  * \param[in] input_info Information structure storing data needed for refreshing templates
  * \return 0 on success, a negative value otherwise
  */
-int convert_packet(char **packet, ssize_t *len, char *input_info);
+int convert_packet(char **packet, ssize_t *len, uint16_t max_len, char *input_info);
 
 /**
  * \brief Reallocate memory for templates

--- a/base/src/input/udp/convert.h
+++ b/base/src/input/udp/convert.h
@@ -46,6 +46,8 @@ enum {
 	SCTP_PLUGIN
 };
 
+#define CONVERSION_ERROR -1
+
 /**
  * \brief Prepare static variables used for inserting template and data sets
  *

--- a/base/src/input/udp/udp_input.c
+++ b/base/src/input/udp/udp_input.c
@@ -75,7 +75,7 @@ IPFIXCOL_API_VERSION;
 /** Identifier to MSG_* macros */
 static char *msg_module = "UDP input";
 
-/** UDP input plugin identification for packet conversion from netflow to ipfix format */
+/** UDP input plugin identification for packet conversion from NetFlow to IPFIX */
 #define UDP_INPUT_PLUGIN
 
 /**
@@ -357,15 +357,16 @@ int get_packet(void *config, struct input_info **info, char **packet, int *sourc
 {
 	/* get socket */
 	int sock = ((struct plugin_conf*) config)->socket;
-	ssize_t length = 0;
-	socklen_t addr_length = sizeof(struct sockaddr_in6);
+	ssize_t len = 0;
+	uint16_t max_msg_len = BUFF_LEN * sizeof(char);
+	socklen_t addr_len = sizeof(struct sockaddr_in6);
 	struct sockaddr_in6 address;
 	struct plugin_conf *conf = config;
 	struct input_info_list *info_list;
 
 	/* allocate memory for packet, if needed */
 	if (!*packet) {
-		*packet = malloc(BUFF_LEN * sizeof(char));
+		*packet = malloc(max_msg_len);
 		if (!*packet) {
 			MSG_ERROR(msg_module, "Memory allocation failed (%s:%d)", __FILE__, __LINE__);
 			return INPUT_ERROR;
@@ -373,8 +374,8 @@ int get_packet(void *config, struct input_info **info, char **packet, int *sourc
 	}
 
 	/* receive packet */
-	length = recvfrom(sock, *packet, BUFF_LEN, 0, (struct sockaddr*) &address, &addr_length);
-	if (length == -1) {
+	len = recvfrom(sock, *packet, BUFF_LEN, 0, (struct sockaddr*) &address, &addr_len);
+	if (len == -1) {
 		if (errno == EINTR) {
 			return INPUT_INTR;
 		}
@@ -383,24 +384,24 @@ int get_packet(void *config, struct input_info **info, char **packet, int *sourc
 		return INPUT_ERROR;
 	}
 
-	if (length < IPFIX_HEADER_LENGTH) {
+	if (len < IPFIX_HEADER_LENGTH) {
 		MSG_ERROR(msg_module, "Packet header is incomplete; skipping message...");
 		return INPUT_INTR;
 	}
 
-	/* Convert packet from Netflow v5/v9/sflow to IPFIX format */
+	/* Try to convert packet from Netflow v5/v9/sflow to IPFIX */
 	if (htons(((struct ipfix_header *) (*packet))->version) != IPFIX_VERSION) {
-		if (convert_packet(packet, &length, (char *) conf->info_list) != 0) {
+		if (convert_packet(packet, &len, max_msg_len, (char *) conf->info_list) != 0) {
 			MSG_WARNING(msg_module, "Message conversion error; skipping message...");
 			return INPUT_INTR;
 		}
 	}
 
 	/* Check if lengths are the same */
-	if (length < htons(((struct ipfix_header *) *packet)->length)) {
+	if (len < htons(((struct ipfix_header *) *packet)->length)) {
 		return INPUT_INTR;
-	} else if (length > htons(((struct ipfix_header *) *packet)->length)) {
-		length = htons(((struct ipfix_header *) *packet)->length);
+	} else if (len > htons(((struct ipfix_header *) *packet)->length)) {
+		len = htons(((struct ipfix_header *) *packet)->length);
 	}
 
 	/* go through input_info_list */
@@ -468,7 +469,7 @@ int get_packet(void *config, struct input_info **info, char **packet, int *sourc
 	/* pass info to the collector */
 	*info = (struct input_info*) info_list;
 
-	return length;
+	return len;
 }
 
 /**


### PR DESCRIPTION
Added some sanity checks in PDU conversion code, to avoid SEGFAULTS as a consequence of non-NetFlow and non-IPFIX PDUs getting to the NFv9 conversion code. This could happen if two bytes in those PDUs at the offset of the NetFlow/IPFIX version number carried a value of '9'. I have added some sanity checks that causes the conversion to fail/stop in case of strange combinations of values. Also, I made many code consistency improvements.