### PR TITLE
Output manager improvements

### DIFF
--- a/base/src/output_manager.c
+++ b/base/src/output_manager.c
@@ -960,20 +960,19 @@ int output_manager_set_mode(enum om_mode mode)
 	if (conf->perman_odid_merge) {
 		/* Nothing can be changed, permanent single manager mode enabled */
 		if (mode == OM_MULTIPLE) {
-			MSG_WARNING(msg_module, "Unable to change output manager mode. "
+			MSG_WARNING(msg_module, "Unable to change Output Manager mode. "
 				"Single manager mode permanently enabled ('-M' argument)");
 		}
 		return 0;
 	}
 
 	if (conf->manager_mode == mode) {
-		/* Mode is still same */
+		/* Mode is still the same */
 		return 0;
 	}
 
 	if (conf->running) {
-		MSG_DEBUG(msg_module, "Stopping Output manager thread");
-		/* Stop output manager's thread */
+		MSG_DEBUG(msg_module, "Stopping Output Manager thread");
 		rbuffer_write(conf->in_queue, NULL, 1);
 		pthread_join(conf->thread_id, NULL);
 	}
@@ -985,6 +984,7 @@ int output_manager_set_mode(enum om_mode mode)
 		aux_config = aux_config->next;
 		data_manager_close(&tmp);
 	}
+
 	conf->data_managers = NULL;
 	conf->last = NULL;
 	conf->manager_mode = mode;
@@ -1000,7 +1000,7 @@ int output_manager_set_mode(enum om_mode mode)
 	if (conf->running) {
 		/* Restart thread */
 		int retval;
-		MSG_DEBUG(msg_module, "Restarting Output manager thread");
+		MSG_DEBUG(msg_module, "Restarting Output Manager thread");
 		retval = pthread_create(&(conf->thread_id), NULL,
 				&output_manager_plugin_thread, (void *) conf);
 		if (retval != 0) {

--- a/base/src/output_manager.c
+++ b/base/src/output_manager.c
@@ -848,6 +848,14 @@ int output_manager_create(configurator *plugins_config, int stat_interval, bool 
 	conf->stat_interval = stat_interval;
 	conf->plugins_config = plugins_config;
 	conf->perman_odid_merge = odid_merge;
+
+	if (conf->manager_mode == OM_SINGLE) {
+		MSG_NOTICE(msg_module, "Configuring Output Manager in single manager mode");
+	} else if (conf->manager_mode == OM_MULTIPLE) {
+		MSG_NOTICE(msg_module, "Configuring Output Manager in multiple manager mode");
+	} else {
+		/* Unknown mode */
+	}
 	
 	*config = conf;
 	return 0;
@@ -980,6 +988,14 @@ int output_manager_set_mode(enum om_mode mode)
 	conf->data_managers = NULL;
 	conf->last = NULL;
 	conf->manager_mode = mode;
+
+	if (mode == OM_SINGLE) {
+		MSG_NOTICE(msg_module, "Switching Output Manager to single manager mode");
+	} else if (mode == OM_MULTIPLE) {
+		MSG_NOTICE(msg_module, "Switching Output Manager to multiple manager mode");
+	} else {
+		/* Unknown mode */
+	}
 
 	if (conf->running) {
 		/* Restart thread */


### PR DESCRIPTION
To avoid confusion about the mode in which the Output Manager is run, the mode is logged upon Output Manager creation and mode change (logging level 'notice').