### PR TITLE
Remove 'NOTICE' logging verbosity

### DIFF
--- a/base/headers/ipfixcol/verbose.h
+++ b/base/headers/ipfixcol/verbose.h
@@ -50,53 +50,50 @@ API extern int skip_seq_err;
 typedef enum {
 	ICMSG_ERROR,
 	ICMSG_WARNING,
-	ICMSG_NOTICE,
+	ICMSG_INFO,
 	ICMSG_DEBUG,
-        ICMSG_INFO,
 } ICMSG_LEVEL;
 
 /**
  * \brief Macros for printing error messages
- * @param module Identification of program part that generated this message
+ * @param module Identification of program component that generated this message
  * @param format
  */
-#define MSG_ERROR(module, format, ...) if(verbose < ICMSG_ERROR); else icmsg_print(ICMSG_ERROR, "ERROR: %s: " format "\n", module, ## __VA_ARGS__)
-#define MSG_WARNING(module, format, ...) if(verbose < ICMSG_WARNING); else icmsg_print(ICMSG_WARNING, "WARNING: %s: " format "\n", module, ## __VA_ARGS__)
-#define MSG_NOTICE(module, format, ...) if(verbose < ICMSG_NOTICE); else icmsg_print(ICMSG_NOTICE, "NOTICE: %s: " format "\n", module, ## __VA_ARGS__)
-#define MSG_DEBUG(module, format, ...) if(verbose < ICMSG_DEBUG); else icmsg_print(ICMSG_DEBUG, "DEBUG: %s: " format "\n", module, ## __VA_ARGS__)
-#define MSG_INFO(module, format, ...) icmsg_print(ICMSG_INFO, "INFO: %s: " format "\n", module, ## __VA_ARGS__)
+#define MSG_ERROR(module, format, ...) if (verbose >= ICMSG_ERROR) icmsg_print(ICMSG_ERROR, "ERROR: %s: " format "\n", module, ## __VA_ARGS__)
+#define MSG_WARNING(module, format, ...) if (verbose >= ICMSG_WARNING) icmsg_print(ICMSG_WARNING, "WARNING: %s: " format "\n", module, ## __VA_ARGS__)
+#define MSG_INFO(module, format, ...) if (verbose >= ICMSG_INFO) icmsg_print(ICMSG_INFO, "INFO: %s: " format "\n", module, ## __VA_ARGS__)
+#define MSG_DEBUG(module, format, ...) if (verbose >= ICMSG_DEBUG) icmsg_print(ICMSG_DEBUG, "DEBUG: %s: " format "\n", module, ## __VA_ARGS__)
 
 /**
- * \brief Macro for printing commong messages, without severity prefix
+ * \brief Macro for printing common messages, without severity prefix.
  *
  * In syslog, all of these messages will have LOG_INFO severity.
  *
  * @param level The verbosity level at which this message should be printed
  * @param format
  */
-#define MSG_COMMON(level, format, ...) if(verbose < level); else icmsg_print(-1, format"\n", ## __VA_ARGS__)
+#define MSG_COMMON(level, format, ...) if (verbose < level); else icmsg_print(-1, format"\n", ## __VA_ARGS__)
 
 /**
- * \brief Macrot for initialising syslog
+ * \brief Macro for initialising syslog.
  *
  * @param ident Identification for syslog
  */
-#define MSG_SYSLOG_INIT(ident) openlog(ident, LOG_PID, LOG_DAEMON); use_syslog = 1
+#define MSG_SYSLOG_INIT(ident) openlog(ident, LOG_PID, LOG_DAEMON); use_syslog = 1;
 
 /**
- * \brief Set verbose level to level
+ * \brief Set verbosity level to the specified level.
  *
  * @param level
  */
 #define MSG_SET_VERBOSE(level) verbose = level;
 
 /**
- * \brief Printing function
+ * \brief Printing function.
  *
- * @param lvl Level of the message (for syslog severity)
+ * @param level Verbosity level of the message (for syslog severity)
  * @param format
  */
-API void icmsg_print(ICMSG_LEVEL lvl, const char *format, ...);
-
+API void icmsg_print(ICMSG_LEVEL level, const char *format, ...);
 
 #endif /* VERBOSE_H_ */

--- a/base/src/config.c
+++ b/base/src/config.c
@@ -608,7 +608,7 @@ struct plugin_xml_conf_list* get_intermediate_plugins(xmlDocPtr config, char *in
 	/* look for <ipfixmedCore> */
 	xpath_obj_core = xmlXPathEvalExpression(BAD_CAST "/ietf-ipfix:ipfix/ietf-ipfix:intermediatePlugins", config_ctxt);
 	if (xpath_obj_core == NULL || xmlXPathNodeSetIsEmpty(xpath_obj_core->nodesetval)) {
-		MSG_NOTICE(msg_module, "No intermediate plugin configured in user configuration");
+		MSG_INFO(msg_module, "No intermediate plugin configured in user configuration");
 		goto cleanup;
 	}
 

--- a/base/src/configurator.c
+++ b/base/src/configurator.c
@@ -230,7 +230,7 @@ int config_remove_input(configurator *config, int index)
 {
 	struct plugin_config *plugin = config->startup->input[index];
 	
-	MSG_NOTICE(msg_module, "[%d] Closing input plugin %d (%s)", config->proc_id, index, plugin->conf.name);
+	MSG_INFO(msg_module, "[%d] Closing input plugin %d (%s)", config->proc_id, index, plugin->conf.name);
 	
 	/* Free plugin */
 	config_free_plugin(plugin);
@@ -251,7 +251,7 @@ int config_remove_inter(configurator *config, int index)
 {
 	struct plugin_config *plugin = config->startup->inter[index];
 	
-	MSG_NOTICE(msg_module, "[%d] Closing intermediate plugin %d (%s)", config->proc_id, index, plugin->conf.name);
+	MSG_INFO(msg_module, "[%d] Closing intermediate plugin %d (%s)", config->proc_id, index, plugin->conf.name);
 	
 	struct ring_buffer *in_queue = NULL, *out_queue = NULL;
 	
@@ -294,7 +294,7 @@ int config_remove_storage(configurator *config, int index)
 {
 	struct plugin_config *plugin = config->startup->storage[index];
 	
-	MSG_NOTICE(msg_module, "[%d] Closing storage plugin %d (%s)", config->proc_id, index, plugin->conf.name);
+	MSG_INFO(msg_module, "[%d] Closing storage plugin %d (%s)", config->proc_id, index, plugin->conf.name);
 	
 	/* Remove it from startup config */
 	config->startup->storage[index] = NULL;
@@ -318,7 +318,7 @@ int config_remove_storage(configurator *config, int index)
  */
 int config_add_input(configurator *config, struct plugin_config *plugin, int index)
 {	
-	MSG_NOTICE(msg_module, "[%d] Opening input plugin: %s", config->proc_id, plugin->conf.file);
+	MSG_INFO(msg_module, "[%d] Opening input plugin: %s", config->proc_id, plugin->conf.file);
 	
 	/* Save configuration */
 	config->input.xml_conf = &(plugin->conf);
@@ -402,7 +402,7 @@ err:
  */
 int config_add_inter(configurator *config, struct plugin_config *plugin, int index)
 {
-	MSG_NOTICE(msg_module, "[%d] Opening intermediate xml_conf: %s", config->proc_id, plugin->conf.file);
+	MSG_INFO(msg_module, "[%d] Opening intermediate xml_conf: %s", config->proc_id, plugin->conf.file);
 	
 	struct intermediate *im_plugin = calloc(1, sizeof(struct intermediate));
 	CHECK_ALLOC(im_plugin, 1);
@@ -519,7 +519,7 @@ err:
  */
 int config_add_storage(configurator *config, struct plugin_config *plugin, int index)
 {
-	MSG_NOTICE(msg_module, "[%d] Opening storage xml_conf: %s", config->proc_id, plugin->conf.file);
+	MSG_INFO(msg_module, "[%d] Opening storage xml_conf: %s", config->proc_id, plugin->conf.file);
 	
 	/* Create storage plugin structure */
 	struct storage *st_plugin = calloc(1, sizeof(struct storage));
@@ -1157,7 +1157,7 @@ void *config_get_current_profiles(configurator *config)
 void config_process_profiles(configurator *config)
 {
 	if (!config->profiles_file) {
-		MSG_NOTICE(msg_module, "No profile configuration");
+		MSG_INFO(msg_module, "No profile configuration");
 		config_replace_profiles(config, NULL);
 		return;
 	}

--- a/base/src/data_manager.c
+++ b/base/src/data_manager.c
@@ -108,7 +108,7 @@ static void* storage_plugin_thread(void *cfg)
 		/* get next data */
 		msg = rbuffer_read(config->thread_config->queue, &index);
 		if (msg == NULL) {
-			MSG_NOTICE("storage plugin thread", "[%u] No more data from Data Manager", config->odid);
+			MSG_INFO("storage plugin thread", "[%u] No more data from Data Manager", config->odid);
             break;
 		}
 		
@@ -147,7 +147,7 @@ static void* storage_plugin_thread(void *cfg)
 		free(starting_msg);
 	}
 
-	MSG_NOTICE("storage plugin thread", "[%u] Closing storage plugin thread", config->odid);
+	MSG_INFO("storage plugin thread", "[%u] Closing storage plugin thread", config->odid);
 	return (NULL);
 }
 

--- a/base/src/input/ipfix/ipfix_file.c
+++ b/base/src/input/ipfix/ipfix_file.c
@@ -108,7 +108,7 @@ static int prepare_input_file(struct ipfix_config *conf)
 		return -1;
 	}
 
-	MSG_NOTICE(msg_module, "Opening input file: %s", conf->input_files[conf->findex]);
+	MSG_INFO(msg_module, "Opening input file: %s", conf->input_files[conf->findex]);
 	
 	fd = open(conf->input_files[conf->findex], O_RDONLY);
 	if (fd == -1) {
@@ -153,7 +153,7 @@ static int close_input_file(struct ipfix_config *conf)
 		return -1;
 	}
 
-	MSG_NOTICE(msg_module, "Input file closed");
+	MSG_INFO(msg_module, "Input file closed");
 
 	conf->fd = -1;
 	return 0;
@@ -273,9 +273,9 @@ int input_init(char *params, void **config)
 	
 	/* print all input files */
 	if (input_files[0] != NULL) {
-		MSG_NOTICE(msg_module, "List of input files:");
+		MSG_INFO(msg_module, "List of input files:");
 		for (i = 0; input_files[i] != NULL; i++) {
-			MSG_NOTICE(msg_module, "\t%s", input_files[i]);
+			MSG_INFO(msg_module, "\t%s", input_files[i]);
 		}
 	}
 	

--- a/base/src/input/sctp/sctp_input.c
+++ b/base/src/input/sctp/sctp_input.c
@@ -190,7 +190,7 @@ void *listen_worker(void *data) {
 		}
 
 		inet_ntop(AF_INET6, &(src_addr6->sin6_addr), printable_ip, INET6_ADDRSTRLEN);
-		MSG_NOTICE(msg_module, "New SCTP association from %s", printable_ip);
+		MSG_INFO(msg_module, "New SCTP association from %s", printable_ip);
 
 		continue;
 
@@ -578,13 +578,13 @@ err_sockaddr6_case:
 		inet_ntop(AF_INET, &(sockaddr_listen[0]->sin_addr), dst_addr, INET6_ADDRSTRLEN);
 	}
 	
-	MSG_NOTICE(msg_module, "Input plugin listening on %s, port %u", dst_addr, conf->listen_port);
+	MSG_INFO(msg_module, "Input plugin listening on %s, port %u", dst_addr, conf->listen_port);
 
 	/* pass general information to the collector */
 	*config = (void*) conf;
 
 	/* normal exit, all OK */
-	MSG_NOTICE(msg_module, "Plugin initialization completed successfully");
+	MSG_INFO(msg_module, "Plugin initialization completed successfully");
 
 	/* do some cleanup */
 	xmlFreeDoc(doc);
@@ -748,7 +748,7 @@ wait_for_data:
 		notification_type = *((uint16_t *) *packet);   /* damn bugs! */
 
 		if (notification_type == SCTP_SHUTDOWN_EVENT) {
-			MSG_NOTICE(msg_module, "SCTP input plugin: Exporter disconnected");
+			MSG_INFO(msg_module, "SCTP input plugin: Exporter disconnected");
 
 			/* remove disconnected socket from event poll */
 			ret = epoll_ctl(conf->epollfd, EPOLL_CTL_DEL, socket, NULL);

--- a/base/src/input/tcp/tcp_input.c
+++ b/base/src/input/tcp/tcp_input.c
@@ -406,7 +406,7 @@ void *input_listen(void *config)
 		} else {
 			inet_ntop(AF_INET6, &address->sin6_addr, src_addr, INET6_ADDRSTRLEN);
 		}
-		MSG_NOTICE(msg_module, "Exporter connected from address %s", src_addr);
+		MSG_INFO(msg_module, "Exporter connected from address %s", src_addr);
 
 		pthread_mutex_unlock(&mutex);
 
@@ -532,7 +532,7 @@ int input_init(char *params, void **config)
 #ifdef TLS_SUPPORT
 		/* check whether we want to enable transport layer security */
 		if (xmlStrEqual(cur_node->name, BAD_CAST "transportLayerSecurity")) {
-			MSG_NOTICE(msg_module, "TLS enabled");
+			MSG_INFO(msg_module, "TLS enabled");
 			conf->tls = 1;   /* TLS enabled */
 			cur_node_parent = cur_node;	
 
@@ -777,7 +777,7 @@ int input_init(char *params, void **config)
 	}
 
 	/* print info */
-	MSG_NOTICE(msg_module, "Input plugin listening on %s, port %s", dst_addr, port);
+	MSG_INFO(msg_module, "Input plugin listening on %s, port %s", dst_addr, port);
 
 	/* start listening thread */
 	if (pthread_create(&listen_thread, NULL, &input_listen, (void *) conf) != 0) {
@@ -790,7 +790,7 @@ int input_init(char *params, void **config)
 	*config = (void*) conf;
 
 	/* normal exit, all OK */
-	MSG_NOTICE(msg_module, "Plugin initialization completed successfully");
+	MSG_INFO(msg_module, "Plugin initialization completed successfully");
 
 out:
 	if (def_port == 0 && port != NULL) { /* free when memory was actually allocated*/
@@ -1074,7 +1074,7 @@ int get_packet(void *config, struct input_info **info, char **packet, int *sourc
 		(*info)->status = SOURCE_STATUS_CLOSED;
 		*source_status = SOURCE_STATUS_CLOSED;
 
-		MSG_NOTICE(msg_module, "Exporter on address %s closed connection", src_addr);
+		MSG_INFO(msg_module, "Exporter on address %s closed connection", src_addr);
 
 		/* use mutex so that listening thread does not reuse the socket too quickly */
 		pthread_mutex_lock(&mutex);
@@ -1192,7 +1192,7 @@ int input_close(void **config)
 	convert_close();
 	*config = NULL;
 
-	MSG_NOTICE(msg_module, "All allocated resources have been freed");
+	MSG_INFO(msg_module, "All allocated resources have been freed");
 
 	return error;
 }

--- a/base/src/input/udp/udp_input.c
+++ b/base/src/input/udp/udp_input.c
@@ -291,13 +291,13 @@ int input_init(char *params, void **config)
 	}
 
 	/* print info */
-	MSG_NOTICE(msg_module, "Input plugin listening on %s, port %s", dst_addr, port);
+	MSG_INFO(msg_module, "Input plugin listening on %s, port %s", dst_addr, port);
 
 	/* and pass it to the collector */
 	*config = (void*) conf;
 
 	/* normal exit, all OK */
-	MSG_NOTICE(msg_module, "Plugin initialization completed successfully");
+	MSG_INFO(msg_module, "Plugin initialization completed successfully");
 
 out:
 	if (default_port == 0 && port != NULL) { /* free when memory was actually allocated */
@@ -426,7 +426,7 @@ int get_packet(void *config, struct input_info **info, char **packet, int *sourc
 
 	/* check whether we found the input_info */
 	if (info_list == NULL) {
-		MSG_NOTICE(msg_module, "New UDP exporter connected (unique port and address)");
+		MSG_INFO(msg_module, "New UDP exporter connected (unique port and address)");
 
 		/* create new input_info */
 		info_list = calloc(1, sizeof(struct input_info_list));
@@ -515,7 +515,7 @@ int input_close(void **config)
 	free(*config);
 	convert_close();
 
-	MSG_NOTICE(msg_module, "All allocated resources have been freed");
+	MSG_INFO(msg_module, "All allocated resources have been freed");
 
 	return 0;
 }

--- a/base/src/intermediate/anonymization/anonymization_ip.c
+++ b/base/src/intermediate/anonymization/anonymization_ip.c
@@ -37,7 +37,6 @@
  *
  */
 
-
 /**
  * \defgroup anonInter Anonymization Intermediate Process
  * \ingroup intermediatePlugins
@@ -47,7 +46,6 @@
  *
  * @{
  */
-
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -256,7 +254,7 @@ int intermediate_init(char *params, void *ip_config, uint32_t ip_id, struct ipfi
 	xmlFreeDoc(doc);
 	xmlCleanupParser();
 
-	MSG_NOTICE(msg_module, "Plugin initialization completed successfully");
+	MSG_INFO(msg_module, "Plugin initialization completed successfully");
 
 	/* plugin successfully initialized */
 	return 0;

--- a/base/src/intermediate/dummy/dummy_ip.c
+++ b/base/src/intermediate/dummy/dummy_ip.c
@@ -57,7 +57,6 @@ IPFIXCOL_API_VERSION;
 
 static char *msg_module = "dummy Intermediate Process";
 
-
 /* plugin's configuration structure */
 struct dummy_ip_config {
 	char *params;
@@ -83,7 +82,7 @@ int intermediate_init(char *params, void *ip_config, uint32_t ip_id, struct ipfi
 
 	*config = conf;
 
-	MSG_NOTICE(msg_module, "Successfully initialized");
+	MSG_INFO(msg_module, "Successfully initialized");
 
 	/* plugin successfully initialized */
 	return 0;

--- a/base/src/intermediate/filter/filter.c
+++ b/base/src/intermediate/filter/filter.c
@@ -338,7 +338,7 @@ int intermediate_init(char *params, void *ip_config, uint32_t ip_id, struct ipfi
 	xmlXPathFreeContext(parser_data.context);
 	xmlFreeDoc(parser_data.doc);
 
-	MSG_NOTICE(msg_module, "Initialized");
+	MSG_INFO(msg_module, "Initialized");
 	return 0;
 
 cleanup_err:

--- a/base/src/intermediate/hooks/hooks.c
+++ b/base/src/intermediate/hooks/hooks.c
@@ -47,7 +47,6 @@
  * @{
  */
 
-
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>
@@ -238,7 +237,7 @@ int intermediate_init(char *params, void *ip_config, uint32_t ip_id, struct ipfi
 	
 	conf->ip_config = ip_config;
 	*config = conf;
-	MSG_NOTICE(msg_module, "Successfully initialized");
+	MSG_INFO(msg_module, "Successfully initialized");
 	return 0;
 	
 cleanup_err:

--- a/base/src/intermediate/joinflows/joinflows_ip.c
+++ b/base/src/intermediate/joinflows/joinflows_ip.c
@@ -653,7 +653,7 @@ int intermediate_init(char *params, void *ip_config, uint32_t ip_id, struct ipfi
 
 	xmlFreeDoc(doc);
 	*config = conf;
-	MSG_NOTICE(msg_module, "Successfully initialized");
+	MSG_INFO(msg_module, "Successfully initialized");
 	return 0;
 }
 
@@ -757,7 +757,7 @@ struct source *joinflows_get_source_by_mapping(struct joinflows_ip_config *conf,
 			/* Add source to list so next time it will be found by joinflows_get_source */
 			new_src->next = conf->sources;
 			conf->sources = new_src;
-			MSG_NOTICE(msg_module, "[%u -> %u] Added implicit source for this join group.", odid, odid);
+			MSG_INFO(msg_module, "[%u -> %u] Added implicit source for this join group.", odid, odid);
 			return new_src;
 		}
 	}

--- a/base/src/intermediate/odip/odip.c
+++ b/base/src/intermediate/odip/odip.c
@@ -111,7 +111,7 @@ int intermediate_init(char *params, void *ip_config, uint32_t ip_id, struct ipfi
 	conf->tm = template_mgr;
 	
 	*config = conf;
-	MSG_NOTICE(msg_module, "Plugin initialization completed successfully");
+	MSG_INFO(msg_module, "Plugin initialization completed successfully");
 	return 0;
 }
 

--- a/base/src/ipfixcol.c
+++ b/base/src/ipfixcol.c
@@ -270,14 +270,14 @@ int main (int argc, char* argv[])
 	if (startup_config == NULL) {
 		/* ... and use default if not specified */
 		startup_config = DEFAULT_STARTUP_CONFIG;
-		MSG_NOTICE(msg_module, "Using default configuration file: %s", startup_config);
+		MSG_INFO(msg_module, "Using default configuration file: %s", startup_config);
 	}
 
 	/* Check internal config file */
 	if (internal_config == NULL) {
 		/* ... and use default if not specified */
 		internal_config = DEFAULT_INTERNAL_CONFIG;
-		MSG_NOTICE(msg_module, "Using default internal configuration file: %s", internal_config);
+		MSG_INFO(msg_module, "Using default internal configuration file: %s", internal_config);
 	}
 	  
 	/* Initialize configurator */
@@ -313,7 +313,7 @@ int main (int argc, char* argv[])
 			/* else child - just continue to handle plugins */
 			config->proc_id = i;
 			
-			MSG_NOTICE(msg_module, "[%d] New collector process started", config->proc_id);
+			MSG_INFO(msg_module, "[%d] New collector process started", config->proc_id);
 		}
 		
 		/* DEBUG - remove this */
@@ -433,10 +433,10 @@ cleanup:
 	if (pid > 0) {
 		for (i = 0; i < proc_count; i++) {
 			pid = wait(NULL);
-			MSG_NOTICE(msg_module, "[%d] Collector child process '%d' terminated", config->proc_id, pid);
+			MSG_INFO(msg_module, "[%d] Collector child process '%d' terminated", config->proc_id, pid);
 		}
 
-		MSG_NOTICE(msg_module, "[%d] Closing collector", config->proc_id);
+		MSG_INFO(msg_module, "[%d] Closing collector", config->proc_id);
 	}
 
 	/* destroy template manager */

--- a/base/src/output_manager.c
+++ b/base/src/output_manager.c
@@ -390,7 +390,7 @@ static void *output_manager_plugin_thread(void* config)
 
 			/* Add config to data_mngmts structure */
 			output_manager_insert(conf, data_config);
-			MSG_NOTICE(msg_module, "[%u] Data Manager created", odid);
+			MSG_INFO(msg_module, "[%u] Data Manager created", odid);
 		}
 
 		if (msg->source_status == SOURCE_STATUS_NEW) {
@@ -429,7 +429,7 @@ static void *output_manager_plugin_thread(void* config)
 		rbuffer_remove_reference(conf->in_queue, index, 0);
 	}
 
-	MSG_NOTICE(msg_module, "Closing Output Manager thread");
+	MSG_INFO(msg_module, "Closing Output Manager thread");
 
 	return (void *) 0;
 }
@@ -863,9 +863,9 @@ int output_manager_create(configurator *plugins_config, int stat_interval, bool 
 	conf->perman_odid_merge = odid_merge;
 
 	if (conf->manager_mode == OM_SINGLE) {
-		MSG_NOTICE(msg_module, "Configuring Output Manager in single manager mode");
+		MSG_INFO(msg_module, "Configuring Output Manager in single manager mode");
 	} else if (conf->manager_mode == OM_MULTIPLE) {
-		MSG_NOTICE(msg_module, "Configuring Output Manager in multiple manager mode");
+		MSG_INFO(msg_module, "Configuring Output Manager in multiple manager mode");
 	} else {
 		/* Unknown mode */
 	}
@@ -1003,9 +1003,9 @@ int output_manager_set_mode(enum om_mode mode)
 	conf->manager_mode = mode;
 
 	if (mode == OM_SINGLE) {
-		MSG_NOTICE(msg_module, "Switching Output Manager to single manager mode");
+		MSG_INFO(msg_module, "Switching Output Manager to single manager mode");
 	} else if (mode == OM_MULTIPLE) {
-		MSG_NOTICE(msg_module, "Switching Output Manager to multiple manager mode");
+		MSG_INFO(msg_module, "Switching Output Manager to multiple manager mode");
 	} else {
 		/* Unknown mode */
 	}

--- a/base/src/preprocessor.c
+++ b/base/src/preprocessor.c
@@ -129,7 +129,7 @@ struct odid_info *odid_info_add_source(uint32_t odid)
 	}
 
 	aux_info->sources++;
-	MSG_NOTICE(msg_module, "[%u] Accepted data from %d. source with this ODID", odid, aux_info->sources);
+	MSG_INFO(msg_module, "[%u] Accepted data from %d. source with this ODID", odid, aux_info->sources);
 	return aux_info;
 }
 
@@ -340,7 +340,7 @@ static int preprocessor_process_one_template(void *tmpl, int max_len, int type,
 		/* check for withdraw template message */
 	} else if (ntohs(template_record->count) == 0) {
 		ret = tm_remove_template(template_mgr, key);
-		MSG_NOTICE(msg_module, "[%u] Received %s withdrawal message", input_info->odid, (type == TM_TEMPLATE) ? "Template" : "Options template");
+		MSG_INFO(msg_module, "[%u] Received %s withdrawal message", input_info->odid, (type == TM_TEMPLATE) ? "Template" : "Options template");
 		/* Log error when removing unknown template */
 		if (ret == 1) {
 			MSG_WARNING(msg_module, "[%u] %s withdrawal message received for unknown template ID %u", input_info->odid,
@@ -354,7 +354,7 @@ static int preprocessor_process_one_template(void *tmpl, int max_len, int type,
 		if (ntohs(template_record->template_id) < 256) {
 			MSG_WARNING(msg_module, "[%u] %s ID %i is reserved and not valid for data set", key->odid, (type == TM_TEMPLATE) ? "Template" : "Options template", ntohs(template_record->template_id));
 		} else {
-			MSG_NOTICE(msg_module, "[%u] New %s ID %i", key->odid, (type == TM_TEMPLATE) ? "template" : "options template", ntohs(template_record->template_id));
+			MSG_INFO(msg_module, "[%u] New %s ID %i", key->odid, (type == TM_TEMPLATE) ? "template" : "options template", ntohs(template_record->template_id));
 			template = tm_add_template(template_mgr, tmpl, max_len, type, key);
 			/* Set new template ID according to ODID */
 			if (template) {

--- a/base/src/storage/dummy/dummy_output.c
+++ b/base/src/storage/dummy/dummy_output.c
@@ -71,7 +71,7 @@ struct dummy_config {
  */
 int storage_init(char *params, void **config)
 {
-	MSG_NOTICE(msg_module, "Dummy plugin: storage_init called");
+	MSG_INFO(msg_module, "Dummy plugin: storage_init called");
 
 	struct dummy_config *conf;
 	xmlDocPtr doc;
@@ -113,7 +113,7 @@ int storage_init(char *params, void **config)
 		cur = cur->next;
 	}
 
-	MSG_NOTICE(msg_module, "Dummy plugin: delay set to %ius", conf->delay);
+	MSG_INFO(msg_module, "Dummy plugin: delay set to %ius", conf->delay);
 
 	/* we don't need this xml tree anymore */
 	xmlFreeDoc(doc);
@@ -157,7 +157,7 @@ int store_now(const void *config)
  */
 int storage_close(void **config)
 {
-	MSG_NOTICE(msg_module, "Dummy plugin: storage_close called\n");
+	MSG_INFO(msg_module, "Dummy plugin: storage_close called\n");
 
 	free(*config);
 	*config = NULL;

--- a/base/src/template_manager.c
+++ b/base/src/template_manager.c
@@ -724,7 +724,7 @@ void tm_remove_all_odid_templates(struct ipfix_template_mgr *tm, uint32_t odid)
 {
 	struct ipfix_template_mgr_record *prev_rec = tm->first, *aux_rec = tm->first;
 
-	MSG_NOTICE(msg_module, "[%u] Removing all templates", odid);
+	MSG_INFO(msg_module, "[%u] Removing all templates", odid);
 
 	while (aux_rec) {
 		if (aux_rec->key >> 32 == odid) {

--- a/base/src/utils/profiles/Channel.cpp
+++ b/base/src/utils/profiles/Channel.cpp
@@ -96,7 +96,7 @@ void Channel::setSources(std::string sources)
 	/* TOP channel, ignore any source specification */
 	if (!m_profile->getParent()) {
 		if (sources != "*") {
-			MSG_NOTICE(msg_module, "Ignoring source specification on top channel %s", m_name.c_str());
+			MSG_INFO(msg_module, "Ignoring source specification on top channel %s", m_name.c_str());
 		}
 		return;
 	}

--- a/base/src/verbose.c
+++ b/base/src/verbose.c
@@ -1,7 +1,7 @@
 /**
  * \file verbose.c
  * \author Petr Velan <petr.velan@cesnet.cz>
- * \brief Main body of the ipfixcol
+ * \brief Main body of ipfixcol
  *
  * Copyright (C) 2015 CESNET, z.s.p.o.
  *
@@ -42,14 +42,14 @@
 #include <stdarg.h>
 #include <syslog.h>
 
-/* Default is to print only errors */
+/* Default is to print errors only */
 int verbose = ICMSG_ERROR;
 
 /* Do not use syslog unless specified otherwise */
 int use_syslog = 0;
 int skip_seq_err = 0;
 
-void icmsg_print(ICMSG_LEVEL lvl, const char *format, ...)
+void icmsg_print(ICMSG_LEVEL level, const char *format, ...)
 {
 	va_list ap;
 	int priority;
@@ -60,13 +60,13 @@ void icmsg_print(ICMSG_LEVEL lvl, const char *format, ...)
 
 	if (use_syslog) {
 		va_start(ap, format);
-		switch (lvl) {
-		case ICMSG_ERROR: priority = LOG_ERR; break;
-		case ICMSG_WARNING: priority = LOG_WARNING; break;
-		case ICMSG_NOTICE: priority = LOG_NOTICE; break;
-		case ICMSG_DEBUG: priority = LOG_DEBUG; break;
-		default: priority = LOG_INFO; break;
+		switch (level) {
+			case ICMSG_ERROR: priority = LOG_ERR; break;
+			case ICMSG_WARNING: priority = LOG_WARNING; break;
+			case ICMSG_DEBUG: priority = LOG_DEBUG; break;
+			default: priority = LOG_INFO; break;
 		}
+
 		vsyslog(priority, format, ap);
 		va_end(ap);
 	}

--- a/base/tests/ipfixcol_test/tests/basic - withdraw message/expected
+++ b/base/tests/ipfixcol_test/tests/basic - withdraw message/expected
@@ -1,2 +1,2 @@
-NOTICE: preprocessor: [0] Received Template withdrawal message
+INFO: preprocessor: [0] Received Template withdrawal message
 WARNING: preprocessor: [0] Template withdrawal message received for unknown template ID 256

--- a/coding_style.md
+++ b/coding_style.md
@@ -71,6 +71,15 @@ if (retval == NULL) {
  */
 ```
 
+#### Verbosity levels
+
+To ensure consistent usage of log verbosity levels, please use the following definitions:
+
+* Error - Something went really wrong, e.g., memory errors or disk full.
+* Warning - This is not right, but I can continue. You should have a look at what happended though.
+* Info - I have something to say, but I don't expect you to listen.
+* Debug - All information that is only interesting for programmers.
+
 #### Other
 
 In case of any doubts or issues other than described in this document, the Linux kernel coding style [1] is leading.

--- a/plugins/input/nfdump/ext_fill.c
+++ b/plugins/input/nfdump/ext_fill.c
@@ -39,12 +39,11 @@
 #include "ext_fill.h"
 #include "nffile.h"
 
-static const char *msg_module = "nfdump input";
-
+static const char *msg_module = "nfdump_input";
 
 //EXTENSION 0 -- not a real extension its just pading ect
 void ext0_fill_tm(uint16_t flags, struct ipfix_template * template){
-	MSG_NOTICE(msg_module, "\tZERO EXTENSION");
+	MSG_INFO(msg_module, "ZERO EXTENSION");
 }
 
 //EXTENSION 1
@@ -335,18 +334,18 @@ void ext22_fill_tm(uint16_t flags, struct ipfix_template * template){
 
 //EXTENSION 23 - Router ipv4
 void ext23_fill_tm(uint16_t flags, struct ipfix_template * template){
-	MSG_WARNING(msg_module, "There is no element for router ip (this extension is ignored)");
+	MSG_WARNING(msg_module, "There is no element for router IP address (this extension is ignored)");
 }
 
 
 //EXTENSION 24 - Router ipv6
 void ext24_fill_tm(uint16_t flags, struct ipfix_template * template){
-	MSG_WARNING(msg_module, "There is no element for router ip (this extension is ignored)");
+	MSG_WARNING(msg_module, "There is no element for router IP address (this extension is ignored)");
 }
 
 //EXTENSION 25 - Router source id
 void ext25_fill_tm(uint16_t flags, struct ipfix_template * template){
-	MSG_NOTICE(msg_module, "There is no element for router sourc id (filled as reserved 38 and 39 elements)");
+	MSG_INFO(msg_module, "There is no element for router source ID (filled as reserved 38 and 39 elements)");
 	template->fields[template->field_count].ie.id = 38;
 	template->fields[template->field_count].ie.length = 1;
 	template->field_count++;

--- a/plugins/input/nfdump/ext_parse.c
+++ b/plugins/input/nfdump/ext_parse.c
@@ -41,12 +41,12 @@
 #include "ext_parse.h"
 #include "nffile.h"
 
-static const char *msg_module = "nfdump input";
+static const char *msg_module = "nfdump_input";
 
 
 //EXTENSION 0 -- not a real extension its just pading ect
 void ext0_parse(uint32_t *data, int *offset, uint16_t flags, struct ipfix_data_set *data_set){
-	//MSG_DEBUG(msg_module, "\tZERO EXTENSION");
+	//MSG_DEBUG(msg_module, "ZERO EXTENSION");
 }
 
 

--- a/plugins/input/nfdump/nfinput.c
+++ b/plugins/input/nfdump/nfinput.c
@@ -69,7 +69,7 @@
 /* API version constant */
 IPFIXCOL_API_VERSION;
 
-static const char *msg_module = "nfdump input";
+static const char *msg_module = "nfdump_input";
 
 #define NO_INPUT_FILE (-2)
 
@@ -955,7 +955,7 @@ static int prepare_input_file(struct nfinput_config *conf)
 		return -1;
 	}
 
-	MSG_NOTICE(msg_module, "Opening input file: %s", conf->input_files[conf->findex]);
+	MSG_INFO(msg_module, "Opening input file: %s", conf->input_files[conf->findex]);
 	
 	fd = open(conf->input_files[conf->findex], O_RDONLY);
 	if (fd == -1) {
@@ -1010,7 +1010,7 @@ static int close_input_file(struct nfinput_config *conf)
 		return -1;
 	}
 
-	MSG_NOTICE(msg_module, "Input file closed");
+	MSG_INFO(msg_module, "Input file closed");
 	conf->fd = -1;
 	return 0;
 }
@@ -1168,9 +1168,9 @@ int input_init(char *params, void **config)
 	
 	/* print all input files */
 	if (input_files[0] != NULL) {
-		MSG_NOTICE(msg_module, "List of input files:");
+		MSG_INFO(msg_module, "List of input files:");
 		for (i = 0; input_files[i] != NULL; i++) {
-			MSG_NOTICE(msg_module, "\t%s", input_files[i]);
+			MSG_INFO(msg_module, "\t%s", input_files[i]);
 		}
 	}
 

--- a/plugins/storage/nfdump/extensions.cpp
+++ b/plugins/storage/nfdump/extensions.cpp
@@ -694,7 +694,7 @@ uint16_t Extension22::fill(uint16_t id, uint16_t size, uint8_t *element_data
 
 //EXTENSION 25 - Router source id
 /*void ext25_fill_tm(uint8_t flags, struct ipfix_data_template * data_template){
-        MSG_NOTICE(msg_str, "There is no element for router sourc id (filled as reserved 38 and 39 elements)");
+        MSG_INFO(msg_str, "There is no element for router sourc id (filled as reserved 38 and 39 elements)");
         data_template->fields[data_template->field_count].ie.id = 38;
         data_template->fields[data_template->field_count].ie.length = 1;
         data_template->field_count++;

--- a/plugins/storage/postgres/postgres_output.c
+++ b/plugins/storage/postgres/postgres_output.c
@@ -1221,7 +1221,7 @@ int storage_close(void **config)
 	conf = (struct postgres_config *) *config;
 
 	PQfinish(conf->conn);
-	MSG_NOTICE(msg_module, "Connection to the database has been closed.");
+	MSG_INFO(msg_module, "Connection to the database has been closed.");
 
 	free(conf->table_names);
 	free(conf);

--- a/plugins/storage/unirec/unirec.c
+++ b/plugins/storage/unirec/unirec.c
@@ -185,11 +185,11 @@ static int init_trap_ifc(unirec_config *conf)
 
 
 	for (int i = 0; i < conf->ifc_count; i++) {
-		MSG_NOTICE(msg_module, "Setting interafece %u buffer %s\n", i, conf->ifc_buff_switch[i] ? "ON" : "OFF");
+		MSG_INFO(msg_module, "Setting interface %u buffer %s\n", i, conf->ifc_buff_switch[i] ? "ON" : "OFF");
 		trap_ctx_ifcctl(conf->trap_ctx_ptr, TRAPIFC_OUTPUT, i, TRAPCTL_BUFFERSWITCH, conf->ifc_buff_switch[i]);
-		MSG_NOTICE(msg_module, "Setting interafece %u autoflush to %llu us\n", i, conf->ifc_buff_timeout[i]);
+		MSG_INFO(msg_module, "Setting interface %u autoflush to %llu us\n", i, conf->ifc_buff_timeout[i]);
 		trap_ctx_ifcctl(conf->trap_ctx_ptr, TRAPIFC_OUTPUT, i, TRAPCTL_AUTOFLUSH_TIMEOUT, conf->ifc_buff_timeout[i]);
-		MSG_NOTICE(msg_module, "Setting interafece %u timeout to %llu us\n", i, conf->ifc[i].timeout);
+		MSG_INFO(msg_module, "Setting interface %u timeout to %llu us\n", i, conf->ifc[i].timeout);
 		trap_ctx_ifcctl(conf->trap_ctx_ptr, TRAPIFC_OUTPUT, i, TRAPCTL_SETTIMEOUT, (int) conf->ifc[i].timeout);
 	}
 	return 1;
@@ -261,7 +261,7 @@ static uint16_t process_record(char *data_record, struct ipfix_template *templat
 	unirecField *matchField;
 
 	uint16_t ipfix_id;
-        uint32_t en_id;
+	uint32_t en_id;
 	uint64_t sec, msec, frac;
 
 	/* Go over all fields */
@@ -298,7 +298,7 @@ static uint16_t process_record(char *data_record, struct ipfix_template *templat
 						switch (matchField->type) {
 							case UNIREC_FIELD_IP:
 								if ((en_id == 0 && (ipfix_id == 8 || ipfix_id == 12)) ||
-								    (en_id == 39499 && ipfix_id == 40)) {
+										(en_id == 39499 && ipfix_id == 40)) {
 									// IPv4 or INVEA_SIP_RTP_IPV4
 									// Put IPv4 into 128 bits in a special way (see ipaddr.h in Nemea-UniRec for details)
 									*(uint64_t*)(conf->ifc[i].buffer + matchField->offset_ar[i]) = 0;
@@ -316,7 +316,7 @@ static uint16_t process_record(char *data_record, struct ipfix_template *templat
 								}
 								else if (template->fields[index].ie.length == 8) {
 									*(uint32_t*)(conf->ifc[i].buffer + matchField->offset_ar[i]) =  ntohl(*(uint32_t*)(data_record + offset + size_length + 4));
-                                                        	} else {
+								} else {
 									*(uint32_t*)(conf->ifc[i].buffer + matchField->offset_ar[i]) =  0xFFFFFFFF;
 								}
 								break;
@@ -340,7 +340,7 @@ static uint16_t process_record(char *data_record, struct ipfix_template *templat
 								if (matchField->size >= length) {
 									data_copy( (conf->ifc[i].buffer) + matchField->offset_ar[i],	// Offset to Unirec buffer for current ifc
 										   (data_record + offset + size_length),		// Offset to data in Ipfix message
-									   	length);						// Size of element
+										length);						// Size of element
 								} else {
 									// set maximum value to unirec element
 									memset( (conf->ifc[i].buffer) + matchField->offset_ar[i],
@@ -462,13 +462,13 @@ static int process_data_sets(const struct ipfix_message *ipfix_msg, unirec_confi
 			// Process data record only once
 			ret = process_record(data_record, template, conf);
 
-			//Check that the record was processes successfuly
+			// Check that the record was processes successfuly
 			if (ret == 0) {
 				return -1;
 			}
 			
- 	             	 //Fill dynamic fields for every UniRec record and send it
-                	for (i = 0; i < conf->ifc_count; i++) {
+			// Fill dynamic fields for every UniRec record and send it
+			for (i = 0; i < conf->ifc_count; i++) {
 				// Check if we have all required fields
 				if (conf->ifc[i].requiredCount == conf->ifc[i].requiredFilled) {
 					// Fill dynamic fields if there are ones
@@ -577,10 +577,10 @@ static int8_t getUnirecFieldTypeFromIpfixId(ipfixElement ipfix_el)
 	uint16_t id = ipfix_el.id;
 	uint32_t en = ipfix_el.en;
 
- 	if ((en == 0 && (id == 8 || id == 12)) ||
-            (en == 39499 && id== 40) ||
-	    (en == 0 && (id == 27 || id == 28)) ||
-            (en == 39499 && id == 41)) {
+	if ((en == 0 && (id == 8 || id == 12)) ||
+			(en == 39499 && id== 40) ||
+		(en == 0 && (id == 27 || id == 28)) ||
+			(en == 39499 && id == 41)) {
 		// IP or INVEA_SIP_RTP_IP
 		return UNIREC_FIELD_IP;
 	} else if (en == 0 && id == 2) {
@@ -973,9 +973,9 @@ static int parse_format(unirec_config *conf_plugin)
 			return 1;
 		}
 		ht = fht_init(1 << round,
-		              FIELDS_HT_KEYSIZE,
-		              sizeof(unirecField*),
-		              FIELDS_HT_STASH_SIZE);
+				FIELDS_HT_KEYSIZE,
+				sizeof(unirecField*),
+				FIELDS_HT_STASH_SIZE);
 		
 		for (dbg_i = 0, currentField = conf_plugin->fields; currentField != NULL ; dbg_i++, currentField = currentField->next) {
 			for (int i = 0; i < currentField->ipfixCount; i++) {
@@ -1029,8 +1029,8 @@ int storage_init (char *params, void **config)
 	unirec_config *conf;
 	xmlDocPtr doc;
 	xmlNodePtr cur;
-        xmlNodePtr cur_sub;
-        int service_ifc_flag = 0;
+	xmlNodePtr cur_sub;
+	int service_ifc_flag = 0;
 	int ifc_count_read = 0;
 	int ifc_count_space = 16;
 	int ifc_count_step = 16;
@@ -1195,7 +1195,6 @@ int storage_init (char *params, void **config)
 		goto err_parse;
 	}
 
-
 	/* Set number of TRAP output interfaces */
 	module_info.num_ifc_out = conf->ifc_count;
 	/* Set verbosity of TRAP library */
@@ -1203,13 +1202,13 @@ int storage_init (char *params, void **config)
 		trap_set_verbose_level(-1);
 	} else if (verbose == ICMSG_WARNING) {
 		trap_set_verbose_level(0); //0
-	} else if (verbose == ICMSG_NOTICE) {
+	} else if (verbose == ICMSG_INFO) {
 		trap_set_verbose_level(1); // 0
 	} else if (verbose == ICMSG_DEBUG) {
 		trap_set_verbose_level(2); // 0
 	}
-	MSG_NOTICE(msg_module, "Verbosity level of TRAP set to %i\n", trap_get_verbose_level());
 
+	MSG_INFO(msg_module, "Verbosity level of TRAP set to %i\n", trap_get_verbose_level());
 
 	/* Initialize Trap */
 	if (!init_trap_ifc(conf)) {
@@ -1265,7 +1264,7 @@ err_init:
  * \return 0 on success, nonzero else.
  */
 int store_packet (void *config, const struct ipfix_message *ipfix_msg,
-        const struct ipfix_template_mgr *template_mgr)
+		const struct ipfix_template_mgr *template_mgr)
 {
 	if (config == NULL || ipfix_msg == NULL) {
 		return -1;
@@ -1327,7 +1326,7 @@ int storage_close (void **config)
 		free(conf->ifc[i].buffer);
 		free(conf->ifc[i].dynAr);
 	}
-        destroy_fields(conf->fields);
+		destroy_fields(conf->fields);
 
 	free(*config);
 	return 0;

--- a/tools/fbitdump/src/Filter.cpp
+++ b/tools/fbitdump/src/Filter.cpp
@@ -889,10 +889,13 @@ void Filter::parseString(parserStruct *ps, std::string text) const throw (std::i
 
 void Filter::parseStringType(parserStruct *ps, parserStruct *col, std::string &cmp) const throw (std::invalid_argument)
 {
+	(void) col;
+
 	if (ps == NULL) {
 		throw std::invalid_argument(std::string("Cannot parse string by type, NULL parser structure"));
 	}
-/*
+
+	/*
 	if (col->parse != NULL) {
 		char buff[PLUGIN_BUFFER_SIZE];
 		col->parse((char *) ps->parts[0].c_str(), buff, col->parseConf);
@@ -901,7 +904,7 @@ void Filter::parseStringType(parserStruct *ps, parserStruct *col, std::string &c
 			ps->type = PT_NUMBER;
 		}
 	}
-*/
+	*/
 
 	if (ps->type == PT_STRING) {
 		/* For all other columns with string value it stays as it is */

--- a/tools/fbitdump/src/Verbose.cpp
+++ b/tools/fbitdump/src/Verbose.cpp
@@ -46,7 +46,6 @@
 /* Default is to print only errors */
 int verbose = ICMSG_ERROR;
 
-
 void icmsg_print(const char *type, const char *module, const char *format, ...)
 {
 	std::cout << type << ": ";

--- a/tools/fbitdump/src/Verbose.h
+++ b/tools/fbitdump/src/Verbose.h
@@ -45,40 +45,51 @@ extern int verbose;
 typedef enum {
 	ICMSG_ERROR,
 	ICMSG_WARNING,
-	ICMSG_NOTICE,
-	ICMSG_DEBUG
+	ICMSG_INFO,
+	ICMSG_DEBUG,
 } ICMSG_LEVEL;
 
 /**
- * \brief Macros for printing error messages
- * @param module Identification of program part that generated this message
- * @param format
+ * \brief Macros for printing error messages.
+ * \param module Identification of program component that generated this message
+ * \param format
  */
 #define MSG_FILTER(module, format, ...) if (verbose >= ICMSG_WARNING) icmsg_print(module, NULL, format, ##__VA_ARGS__)
 #define MSG_ERROR(module, format, ...) if (verbose >= ICMSG_ERROR) icmsg_print("ERROR", module, format, ##__VA_ARGS__)
 #define MSG_WARNING(module, format, ...) if (verbose >= ICMSG_WARNING) icmsg_print("WARNING", module, format, ## __VA_ARGS__)
-#define MSG_NOTICE(module, format, ...) if (verbose >= ICMSG_NOTICE) icmsg_print("NOTICE", module, format, ## __VA_ARGS__)
+#define MSG_INFO(module, format, ...) if (verbose >= ICMSG_INFO) icmsg_print("INFO", module, format, ## __VA_ARGS__)
 #define MSG_DEBUG(module, format, ...) if (verbose >= ICMSG_DEBUG) icmsg_print("DEBUG", module, format, ## __VA_ARGS__)
 
 /**
- * \brief Macro for printing commong messages, without severity prefix
+ * \brief Macro for printing common messages, without severity prefix.
  *
- * @param level The verbosity level at which this message should be printed
- * @param format
+ * In syslog, all of these messages will have LOG_INFO severity.
+ *
+ * \param level The verbosity level at which this message should be printed
+ * \param format
  */
-#define MSG_COMMON(level, format, ...) if(verbose < level); else icmsg_print(-1, format"\n", ## __VA_ARGS__)
+#define MSG_COMMON(level, format, ...) if (verbose < level); else icmsg_print(-1, format"\n", ## __VA_ARGS__)
 
 /**
- * \brief Set verbose level to level
+ * \brief Macro for initialising syslog.
  *
- * @param level
+ * \param ident Identification for syslog
+ */
+#define MSG_SYSLOG_INIT(ident) openlog(ident, LOG_PID, LOG_DAEMON);
+
+/**
+ * \brief Set verbosity level to the specified level.
+ *
+ * \param level
  */
 #define MSG_SET_VERBOSE(level) verbose = level;
 
 /**
- * \brief Printing function
+ * \brief Printing function.
  *
- * @param format
+ * \param level Verbosity level of the message (for syslog severity)
+ * \param module
+ * \param format
  */
 void icmsg_print(const char *type, const char *module, const char *format, ...);
 

--- a/tools/fbitexpire/src/PipeListener.cpp
+++ b/tools/fbitexpire/src/PipeListener.cpp
@@ -86,21 +86,21 @@ void PipeListener::loop()
 				switch(_buff[0]) {
 				case 'r':
 					/* rescan folder */
-					MSG_NOTICE(msg_module, "triggered rescan of %s", _buff.substr(1).c_str());
+					MSG_INFO(msg_module, "triggered rescan of %s", _buff.substr(1).c_str());
 					_buff = _buff.substr(1);
 					_scanner->rescan(_buff);
 					break;
 				case 'k':
 					/* Stop daemon */
-					MSG_NOTICE(msg_module, "triggered daemon termination");
+					MSG_INFO(msg_module, "triggered daemon termination");
 					_done = true;
 					break;
 				case 's':
-					MSG_NOTICE(msg_module, "setting max. directory size (%s)", _buff.substr(1).c_str());
+					MSG_INFO(msg_module, "setting max. directory size (%s)", _buff.substr(1).c_str());
 					_scanner->setMaxSize(_buff.substr(1), true);
 					break;
 				case 'w':
-					MSG_NOTICE(msg_module, "setting lower limit (%s)", _buff.substr(1).c_str());
+					MSG_INFO(msg_module, "setting lower limit (%s)", _buff.substr(1).c_str());
 					_scanner->setWatermark(_buff.substr(1));
 					break;
 				}

--- a/tools/fbitexpire/src/fbitexpire.cpp
+++ b/tools/fbitexpire/src/fbitexpire.cpp
@@ -265,7 +265,7 @@ int main(int argc, char *argv[])
 		if (pipe_exists) {
 			MSG_ERROR(msg_module, "active pipe (%s) detected", pipe.c_str());
 			MSG_ERROR(msg_module, "fbitexpire supports only a single instance per pipe");
-			MSG_NOTICE(msg_module, "please restart using different pipe (-p)");
+			MSG_INFO(msg_module, "please restart using different pipe (-p)");
 			return 1;
 		} else if (remove(pipe.c_str()) != 0) {
 			// Remove invalid pipe
@@ -318,7 +318,7 @@ int main(int argc, char *argv[])
 	}
 	
 	if (!depth_set) {
-		MSG_NOTICE(msg_module, "depth not set; using default (%d)", DEFAULT_DEPTH);
+		MSG_INFO(msg_module, "depth not set; using default (%d)", DEFAULT_DEPTH);
 	}
 	
 	std::string basedir{argv[optind]};
@@ -334,7 +334,7 @@ int main(int argc, char *argv[])
 	if (daemonize) {
 		closelog();
 		MSG_SYSLOG_INIT(PACKAGE);
-		MSG_NOTICE(msg_module, "daemonizing...");
+		MSG_INFO(msg_module, "daemonizing...");
 		
 		/* and send all following messages to the syslog */
 		if (daemon (1, 0)) {

--- a/tools/fbitexpire/src/verbose.cpp
+++ b/tools/fbitexpire/src/verbose.cpp
@@ -68,11 +68,11 @@ void icmsg_print_common(const char *format, ...)
 	}
 }
 
-void icmsg_print(ICMSG_LEVEL lvl, const char *prefix, const char *module, const char *format, ...)
+void icmsg_print(ICMSG_LEVEL level, const char *type, const char *module, const char *format, ...)
 {
 	std::stringstream msg;
 	
-	msg << prefix << ": " << module << ": " << format << "\n";
+	msg << type << ": " << module << ": " << format << "\n";
 	
 	va_list ap;
 	int priority;
@@ -83,13 +83,13 @@ void icmsg_print(ICMSG_LEVEL lvl, const char *prefix, const char *module, const 
 
 	if (use_syslog) {
 		va_start(ap, format);
-		switch (lvl) {
-		case ICMSG_ERROR:   priority = LOG_ERR;     break;
-		case ICMSG_WARNING: priority = LOG_WARNING; break;
-		case ICMSG_NOTICE:  priority = LOG_NOTICE;  break;
-		case ICMSG_DEBUG:   priority = LOG_DEBUG;   break;
-		default:            priority = LOG_INFO;    break;
+		switch (level) {
+			case ICMSG_ERROR:   priority = LOG_ERR;     break;
+			case ICMSG_WARNING: priority = LOG_WARNING; break;
+			case ICMSG_DEBUG:   priority = LOG_DEBUG;   break;
+			default:            priority = LOG_INFO;    break;
 		}
+
 		vsyslog(priority, msg.str().c_str(), ap);
 		va_end(ap);
 	}

--- a/tools/fbitexpire/src/verbose.h
+++ b/tools/fbitexpire/src/verbose.h
@@ -40,53 +40,57 @@
 #ifndef VERBOSE_H_
 #define VERBOSE_H_
 
-extern int  verbose;
+extern int verbose;
 extern bool use_syslog;
 
 typedef enum {
 	ICMSG_ERROR,
 	ICMSG_WARNING,
-	ICMSG_NOTICE,
-	ICMSG_DEBUG
+	ICMSG_INFO,
+	ICMSG_DEBUG,
 } ICMSG_LEVEL;
 
 /**
- * \brief Macros for printing error messages
- * 
- * \param module Identification of program part that generated this message
- * \param format
+ * \brief Macros for printing error messages.
+ * @param module Identification of program component that generated this message
+ * @param format
  */
-#define MSG_ERROR(module, format, ...) if(verbose < ICMSG_ERROR); else icmsg_print(ICMSG_ERROR, "ERROR", module, format, ## __VA_ARGS__)
-#define MSG_WARNING(module, format, ...) if(verbose < ICMSG_WARNING); else icmsg_print(ICMSG_WARNING, "WARNING", module, format, ## __VA_ARGS__)
-#define MSG_NOTICE(module, format, ...) if(verbose < ICMSG_NOTICE); else icmsg_print(ICMSG_NOTICE, "NOTICE", module, format, ## __VA_ARGS__)
-#define MSG_DEBUG(module, format, ...) if(verbose < ICMSG_DEBUG); else icmsg_print(ICMSG_DEBUG, "DEBUG", module, format, ## __VA_ARGS__)
+#define MSG_ERROR(module, format, ...) if (verbose >= ICMSG_ERROR) icmsg_print(ICMSG_ERROR, "ERROR", module, format, ##__VA_ARGS__)
+#define MSG_WARNING(module, format, ...) if (verbose >= ICMSG_WARNING) icmsg_print(ICMSG_WARNING, "WARNING", module, format, ## __VA_ARGS__)
+#define MSG_INFO(module, format, ...) if (verbose >= ICMSG_INFO) icmsg_print(ICMSG_INFO, "INFO", module, format, ## __VA_ARGS__)
+#define MSG_DEBUG(module, format, ...) if (verbose >= ICMSG_DEBUG) icmsg_print(ICMSG_DEBUG, "DEBUG", module, format, ## __VA_ARGS__)
 
 /**
- * \brief Macrot for initialising syslog
+ * \brief Macro for printing common messages, without severity prefix.
  *
- * \param ident Identification for syslog
+ * In syslog, all of these messages will have LOG_INFO severity.
+ *
+ * @param level The verbosity level at which this message should be printed
+ * @param format
  */
-#define MSG_SYSLOG_INIT(ident) openlog(ident, LOG_PID, LOG_DAEMON); use_syslog = true
-
-
 #define MSG_COMMON(format, ...) icmsg_print_common(format, ## __VA_ARGS__)
 
 /**
- * \brief Set verbose level to level
+ * \brief Macro for initialising syslog.
  *
- * \param level
+ * @param ident Identification for syslog
+ */
+#define MSG_SYSLOG_INIT(ident) openlog(ident, LOG_PID, LOG_DAEMON); use_syslog = true;
+
+/**
+ * \brief Set verbosity level to the specified level.
+ *
+ * @param level
  */
 #define MSG_SET_VERBOSE(level) verbose = level;
 
 /**
- * \brief Printing function
+ * \brief Printing function.
  *
- * \param lvl Level of the message (for syslog severity)
- * \param prefix Message prefix (ERROR, NOTICE...)
- * \param module Module name
- * \param format message format
+ * @param level Verbosity level of the message (for syslog severity)
+ * @param format
  */
-void icmsg_print(ICMSG_LEVEL lvl, const char *prefix, const char *module, const char *format, ...);
+void icmsg_print(ICMSG_LEVEL level, const char *type, const char *module, const char *format, ...);
 void icmsg_print_common(const char *format, ...);
 
 #endif /* VERBOSE_H_ */

--- a/tools/profilesdaemon/src/profilesdaemon.cpp
+++ b/tools/profilesdaemon/src/profilesdaemon.cpp
@@ -150,7 +150,7 @@ int main(int argc, char *argv[])
 	if (daemonize) {
 		closelog();
 		MSG_SYSLOG_INIT("profilesdaemon");
-		MSG_NOTICE("daemonizing...");
+		MSG_INFO("daemonizing...");
 
 		if (daemon(1, 0)) {
 			MSG_ERROR("daemon(): %s", strerror(errno));

--- a/tools/profilesdaemon/src/verbose.cpp
+++ b/tools/profilesdaemon/src/verbose.cpp
@@ -68,11 +68,11 @@ void icmsg_print_common(const char *format, ...)
 	}
 }
 
-void icmsg_print(ICMSG_LEVEL lvl, const char *prefix, const char *format, ...)
+void icmsg_print(ICMSG_LEVEL level, const char *type, const char *format, ...)
 {
 	std::stringstream msg;
 	
-	msg << prefix << ": " << format << "\n";
+	msg << *type << ": " << format << "\n";
 	
 	va_list ap;
 	int priority;
@@ -83,12 +83,11 @@ void icmsg_print(ICMSG_LEVEL lvl, const char *prefix, const char *format, ...)
 
 	if (use_syslog) {
 		va_start(ap, format);
-		switch (lvl) {
-		case ICMSG_ERROR:   priority = LOG_ERR;     break;
-		case ICMSG_WARNING: priority = LOG_WARNING; break;
-		case ICMSG_NOTICE:  priority = LOG_NOTICE;  break;
-		case ICMSG_DEBUG:   priority = LOG_DEBUG;   break;
-		default:            priority = LOG_INFO;    break;
+		switch (level) {
+			case ICMSG_ERROR:   priority = LOG_ERR;     break;
+			case ICMSG_WARNING: priority = LOG_WARNING; break;
+			case ICMSG_DEBUG:   priority = LOG_DEBUG;   break;
+			default:            priority = LOG_INFO;    break;
 		}
 		vsyslog(priority, msg.str().c_str(), ap);
 		va_end(ap);

--- a/tools/profilesdaemon/src/verbose.h
+++ b/tools/profilesdaemon/src/verbose.h
@@ -40,53 +40,57 @@
 #ifndef VERBOSE_H_
 #define VERBOSE_H_
 
-extern int  verbose;
+extern int verbose;
 extern bool use_syslog;
 
 typedef enum {
 	ICMSG_ERROR,
 	ICMSG_WARNING,
-	ICMSG_NOTICE,
-	ICMSG_DEBUG
+	ICMSG_INFO,
+	ICMSG_DEBUG,
 } ICMSG_LEVEL;
 
 /**
- * \brief Macros for printing error messages
- * 
- * \param module Identification of program part that generated this message
+ * \brief Macros for printing error messages.
  * \param format
  */
-#define MSG_ERROR(format, ...) if(verbose < ICMSG_ERROR); else icmsg_print(ICMSG_ERROR, "ERROR", format, ## __VA_ARGS__)
-#define MSG_WARNING(format, ...) if(verbose < ICMSG_WARNING); else icmsg_print(ICMSG_WARNING, "WARNING", format, ## __VA_ARGS__)
-#define MSG_NOTICE(format, ...) if(verbose < ICMSG_NOTICE); else icmsg_print(ICMSG_NOTICE, "NOTICE", format, ## __VA_ARGS__)
-#define MSG_DEBUG(format, ...) if(verbose < ICMSG_DEBUG); else icmsg_print(ICMSG_DEBUG, "DEBUG", format, ## __VA_ARGS__)
+#define MSG_ERROR(format, ...) if (verbose >= ICMSG_ERROR) icmsg_print(ICMSG_ERROR, "ERROR", format, ##__VA_ARGS__)
+#define MSG_WARNING(format, ...) if (verbose >= ICMSG_WARNING) icmsg_print(ICMSG_WARNING, "WARNING", format, ## __VA_ARGS__)
+#define MSG_INFO(format, ...) if (verbose >= ICMSG_INFO) icmsg_print(ICMSG_INFO, "INFO", format, ## __VA_ARGS__)
+#define MSG_DEBUG(format, ...) if (verbose >= ICMSG_DEBUG) icmsg_print(ICMSG_DEBUG, "DEBUG", format, ## __VA_ARGS__)
 
 /**
- * \brief Macrot for initialising syslog
+ * \brief Macro for printing common messages, without severity prefix.
  *
- * \param ident Identification for syslog
+ * In syslog, all of these messages will have LOG_INFO severity.
+ *
+ * \param level The verbosity level at which this message should be printed
+ * \param format
  */
-#define MSG_SYSLOG_INIT(ident) openlog(ident, LOG_PID, LOG_DAEMON); use_syslog = true
-
-
 #define MSG_COMMON(format, ...) icmsg_print_common(format, ## __VA_ARGS__)
 
 /**
- * \brief Set verbose level to level
+ * \brief Macro for initialising syslog.
+ *
+ * \param ident Identification for syslog
+ */
+#define MSG_SYSLOG_INIT(ident) openlog(ident, LOG_PID, LOG_DAEMON); use_syslog = true;
+
+/**
+ * \brief Set verbosity level to the specified level.
  *
  * \param level
  */
 #define MSG_SET_VERBOSE(level) verbose = level;
 
 /**
- * \brief Printing function
+ * \brief Printing function.
  *
- * \param lvl Level of the message (for syslog severity)
- * \param prefix Message prefix (ERROR, NOTICE...)
- * \param module Module name
- * \param format message format
+ * \param level Verbosity level of the message (for syslog severity)
+ * \param type
+ * \param format
  */
-void icmsg_print(ICMSG_LEVEL lvl, const char *prefix, const char *format, ...);
+void icmsg_print(ICMSG_LEVEL level, const char *type, const char *format, ...);
 void icmsg_print_common(const char *format, ...);
 
 #endif /* VERBOSE_H_ */


### PR DESCRIPTION
In order to get some more consistency between in the logging verbosities used by the various IPFIXcol components, I performed the following changes:

* Removed 'NOTICE' logging verbosity
* Changed `MSG_NOTICE` into `MSG_INFO`
* Updated coding style conventions to include a note on logging verbosities
* Improved code consistency between various IPFIXcol components in terms of how logging is implemented

A careful review of the performed changes is very welcome.