### PR TITLE
compile option required

### DIFF
--- a/plugins/storage/lnfstore/configure.ac
+++ b/plugins/storage/lnfstore/configure.ac
@@ -48,7 +48,7 @@ AC_CONFIG_SRCDIR([lnfstore.c])
 AC_CONFIG_HEADERS([config.h])
 
 # Initialization
-CFLAGS="-Wall"
+CFLAGS="-Wall -std=gnu99"
 
 RELEASE=1
 AC_SUBST(RELEASE)


### PR DESCRIPTION
lnfstore.c: In function 'store_packet':
lnfstore.c:133:2: error: 'for' loop initial declarations are only allowed in C99 or C11 mode
  for(int i = 0; i < ipfix_msg->data_records_count; i++)
  ^
lnfstore.c:133:2: note: use option -std=c99, -std=gnu99, -std=c11 or -std=gnu11 to compile your code
Makefile:489: recipe for target 'lnfstore.lo' failed