### PR TITLE
Preparations for multi-instanced fields

### DIFF
--- a/base/headers/ipfixcol/ipfix_message.h
+++ b/base/headers/ipfixcol/ipfix_message.h
@@ -175,7 +175,7 @@ API void data_set_set_field(struct ipfix_data_set *set, struct ipfix_template *t
  * \brief Get template record field
  *
  * \param[in] rec Template record
- * * \param[in] enterprise Enterprise number
+ * \param[in] enterprise Enterprise number
  * \param[in] id  field id
  * \param[out] data_offset offset data record specified by this template record
  * \return pointer to inserted field
@@ -267,8 +267,6 @@ API void message_free_metadata(struct ipfix_message *msg);
  */
 API struct metadata *message_copy_metadata(struct ipfix_message *src);
 
-
 #endif /* IPFIX_MESSAGE_H_ */
 
 /**@}*/
-

--- a/base/headers/ipfixcol/ipfix_message.h
+++ b/base/headers/ipfixcol/ipfix_message.h
@@ -79,7 +79,6 @@ API struct ipfix_message *message_create_from_mem(void *msg, int len, struct inp
  */
 API struct ipfix_message *message_create_clone(struct ipfix_message *msg);
 
-
 /**
  * \brief Create empty IPFIX message
  *
@@ -97,7 +96,6 @@ API struct ipfix_message *message_create_empty();
  */
 API int message_get_data(uint8_t **dest, uint8_t *source, int len);
 
-
 /**
  * \brief Set data to IPFIX message.
  *
@@ -108,7 +106,6 @@ API int message_get_data(uint8_t **dest, uint8_t *source, int len);
  */
 API int message_set_data(uint8_t *dest, uint8_t *source, int len);
 
-
 /**
  * \brief Get pointers to start of the Data Records in specific Data Set
  *
@@ -118,7 +115,6 @@ API int message_set_data(uint8_t *dest, uint8_t *source, int len);
  */
 API uint8_t **get_data_records(struct ipfix_data_set *data_set, struct ipfix_template *tmplt);
 
-
 /**
  * \brief Get offset where next data record starts
  *
@@ -127,7 +123,6 @@ API uint8_t **get_data_records(struct ipfix_data_set *data_set, struct ipfix_tem
  * \return offset of next data record in data set
  */
 API uint16_t get_next_data_record_offset(uint8_t *data_record, struct ipfix_template *tmplt);
-
 
 /**
  * \brief Dispose IPFIX message
@@ -201,6 +196,34 @@ API struct ipfix_template_row *template_record_get_field(struct ipfix_template_r
  * \return pointer to inserted field
  */
 API struct ipfix_template_row *template_get_field(struct ipfix_template *templ, uint32_t enterprise, uint16_t id, int *data_offset);
+
+/**
+ * \brief Get offset of next field instance in data record. For variable-length
+ * fields, the returned offset does not include the field's length indicators (i.e.,
+ * the first byte, or the first three bytes, of the field).
+ *
+ * \param[in] data_record Data record
+ * \param[in] template Data record's template
+ * \param[in] enterprise Enterprise number
+ * \param[in] id Field ID
+ * \param[in] from_offset Offset to start at (default: -1)
+ * \param[out] data_length Field length
+ * \return Field offset
+ */
+API int data_record_field_next_offset(uint8_t *data_record, struct ipfix_template *templ,
+        uint32_t enterprise, uint16_t id, int from_offset, int *data_length);
+
+/**
+ * \brief Get offset of field in data record
+ *
+ * \param[in] data_record Data record
+ * \param[in] template Data record's template
+ * \param[in] enterprise Enterprise number
+ * \param[in] id Field ID
+ * \param[out] data_length Field length
+ * \return Field offset
+ */
+API int data_record_field_offset(uint8_t *data_record, struct ipfix_template *templ, uint32_t enterprise, uint16_t id, int *data_length);
 
 /**
  * \brief Compute data record's length

--- a/base/headers/ipfixcol/ipfix_message.h
+++ b/base/headers/ipfixcol/ipfix_message.h
@@ -172,6 +172,15 @@ API void data_record_set_field(uint8_t *record, struct ipfix_template *templ, ui
 API void data_set_set_field(struct ipfix_data_set *set, struct ipfix_template *templ, uint32_t enterprise, uint16_t id, uint8_t *value);
 
 /**
+ * \brief Count the number of occurrences of the specified field
+ * \param[in] rec Template record
+ * \param[in] enterprise Field enterprise ID
+ * \param[in] id Field ID
+ * \return Number of field occurrences
+ */
+API int template_record_count_field_occurences(struct ipfix_template_record *rec, uint32_t enterprise, uint16_t id);
+
+/**
  * \brief Get template record field
  *
  * \param[in] rec Template record

--- a/base/headers/ipfixcol/templates.h
+++ b/base/headers/ipfixcol/templates.h
@@ -102,27 +102,23 @@ enum offset_fields {
  * All data in this structure are in host byte order
  */
 struct ipfix_template {
-	uint16_t original_id;			 /** Original template ID */
-	uint32_t references;		 /** Number of packets referencing to this template */
+	uint16_t original_id;        /** Original template ID */
+	uint32_t references;         /** Number of packets referencing to this template */
 	struct ipfix_template *next; /** Pointer to older template with the same template id */
-
-	uint8_t template_type;       /**Type of Template - TM_TEMPLATE = Template,
-	                              * TM_OPTIONS_TEMPLATE = Options Template */
-	time_t first_transmission;	 /** Time of first transmission of Template,
-								   UDP only */
-	time_t last_transmission;    /**Time of last transmission of Template,
-	                              * UDP only */
-	uint32_t last_message;		 /** Message number of last update,
-	 	 	 	 	 	 	 	  * UDP only */
-	uint16_t template_id;        /**Template ID given by collector */
-	uint16_t field_count;        /**Number of fields in Template Record */
-	uint16_t scope_field_count;  /**Number of scope fields */
-	uint16_t template_length;    /**Length of the template. This is size
+	uint8_t template_type;       /** Type of Template - TM_TEMPLATE = Template,
+	                              *  TM_OPTIONS_TEMPLATE = Options Template */
+	time_t first_transmission;   /** Time of first transmission of Template, UDP only */
+	time_t last_transmission;    /** Time of last transmission of Template, UDP only */
+	uint32_t last_message;       /** Message number of last update, UDP only */
+	uint16_t template_id;        /** Template ID given by collector */
+	uint16_t field_count;        /** Number of fields in Template Record */
+	uint16_t scope_field_count;  /** Number of scope fields */
+	uint16_t template_length;    /** Length of the template. This is size
 	                              * of the template structure and actual template
 	                              * fields.
 	                              * sizeof(struct ipfix_template) - sizeof(template_ie)
 	                              * + length of the template fields */
-	uint32_t data_length;        /**Length of the data record specified
+	uint32_t data_length;        /** Length of the data record specified
 	                              * by this template. If the most significant
 	                              * bit is set to 1, then there is at least
 	                              * one Information Element with variable length.
@@ -131,7 +127,7 @@ struct ipfix_template {
 	                              * calculated somehow else. For more information,
 	                              * see section 7 in RFC 5101. */
 	int offsets[OF_COUNT];
-	template_ie fields[1];       /**Template fields */
+	template_ie fields[1];       /** Template fields */
 };
 
 /**
@@ -166,7 +162,6 @@ struct ipfix_template_mgr_record {
 	struct ipfix_template_mgr_record *next; /** pointer to next record in template manager's list */
 };
 
-
 /**
  * \brief Function for creating new template
  *
@@ -179,7 +174,6 @@ struct ipfix_template_mgr_record {
  * \return Pointer to new ipfix_template on success, NULL otherwise
  */
 API struct ipfix_template *tm_create_template(void *tmp, int max_len, int type, uint32_t odid);
-
 
 /**
  * \brief Function for adding new templates.
@@ -195,7 +189,6 @@ API struct ipfix_template *tm_create_template(void *tmp, int max_len, int type, 
  */
 API struct ipfix_template *tm_add_template(struct ipfix_template_mgr *tm,
                                           void *tmp, int max_len, int type, struct ipfix_template_key *key);
-
 
 /**
  * \brief Insert existing template into Template Manager
@@ -220,7 +213,6 @@ API struct ipfix_template *tm_insert_template(struct ipfix_template_mgr *tm, str
  */
 API struct ipfix_template *tm_update_template(struct ipfix_template_mgr *tm,
                                           void *tmp, int max_len, int type, struct ipfix_template_key *key);
-
 /**
  * \brief Function for specific Template lookup.
  *
@@ -311,50 +303,50 @@ API void tm_destroy(struct ipfix_template_mgr *tm);
 /**
  * \brief Make ipfix_template_key from ODID, crc and template id
  * 
- * @param odid Observation Domain ID
- * @param crc  CRC from source IP and source port
- * @param tid  Template ID
- * @return pointer to ipfix_template_key
+ * \param[in] odid Observation Domain ID
+ * \param[in] crc  CRC from source IP and source port
+ * \param[in] tid  Template ID
+ * \return pointer to ipfix_template_key
  */
 API struct ipfix_template_key *tm_key_create(uint32_t odid, uint32_t crc, uint32_t tid);
 
 /**
  * \brief Change Template ID in template_key
  *
- * @param key Template identifier in Template Manager
- * @param tid New Template ID
- * @return pointer to changed ipfix_template_key
+ * \param[in] key Template identifier in Template Manager
+ * \param[in] tid New Template ID
+ * \return pointer to changed ipfix_template_key
  */
 API struct ipfix_template_key *tm_key_change_template_id(struct ipfix_template_key *key, uint32_t tid);
 
 /**
  * \brief Destroy ipfix_template_key structure
  * 
- * @param key IPFIX template key
+ * \param[in] key IPFIX template key
  */
 API void tm_key_destroy(struct ipfix_template_key *key);
 
 /**
  * \brief Get template record length
  *
- * @param templ Template record
- * @param max_len Maximum length of the template record. Typically length
+ * \param[in] templ Template record
+ * \param[in] max_len Maximum length of the template record. Typically length
  * to the end of the Template Set.
  * @param type Type of the Template Record. TM_TEMPLATE = Template,
  * TM_OPTIONS_TEMPLATE = Options Template.
- * @param data_length Length of the data record specified by this template record
+ * \param[out] data_length Length of the data record specified by this template record
+ * \return Template record length
  */
 API uint16_t tm_template_record_length(struct ipfix_template_record *templ, int max_len, int type, uint32_t *data_length);
 
 /**
  * \brief Compare 2 template records
  *
- * @param first First template record
- * @param second Second template record
- * @return non-zero if templates are equal
+ * \param[in] first First template record
+ * \param[in] second Second template record
+ * \return Non-zero if templates are equal
  */
 API int tm_compare_template_records(struct ipfix_template_record *first, struct ipfix_template_record *second);
-
 
 API extern struct ipfix_template_mgr *template_mgr;
 #endif /* IPFIXCOL_TEMPLATES_H_ */

--- a/base/src/ipfix_message.c
+++ b/base/src/ipfix_message.c
@@ -257,10 +257,8 @@ uint16_t get_next_data_record_offset(uint8_t *data_record, struct ipfix_template
 			++index;
 		}
 
-		if (length != VAR_IE_LENGTH) {
-			offset += length;
-		} else {
-			/* variable length */
+		if (length == VAR_IE_LENGTH) {
+			/* Variable length */
 			length = read8(data_record+offset);
 			offset += 1;
 
@@ -269,6 +267,8 @@ uint16_t get_next_data_record_offset(uint8_t *data_record, struct ipfix_template
 				offset += 2;
 			}
 
+			offset += length;
+		} else {
 			offset += length;
 		}
 
@@ -527,10 +527,8 @@ int data_record_field_offset(uint8_t *data_record, struct ipfix_template *templa
 				offset += length;
 				break;
 			default:
-				if (length != VAR_IE_LENGTH) {
-					offset += length;
-				} else {
-					/* variable length */
+				if (length == VAR_IE_LENGTH) {
+					/* Variable length */
 					length = *((uint8_t *) (data_record+offset));
 					offset += 1;
 
@@ -540,6 +538,8 @@ int data_record_field_offset(uint8_t *data_record, struct ipfix_template *templa
 					}
 
 					prevoffset = offset;
+					offset += length;
+				} else {
 					offset += length;
 				}
 
@@ -640,18 +640,18 @@ uint16_t data_record_length(uint8_t *data_record, struct ipfix_template *templat
 			offset += length;
 			break;
 		default:
-			if (length != VAR_IE_LENGTH) {
-				offset += length;
-			} else {
-				/* variable length */
-				length = *((uint8_t *) (data_record+offset));
+			if (length == VAR_IE_LENGTH) {
+				/* Variable length */
+				length = *((uint8_t *) (data_record + offset));
 				offset += 1;
 
 				if (length == 255) {
-					length = ntohs(*((uint16_t *) (data_record+offset)));
+					length = ntohs(*((uint16_t *) (data_record + offset)));
 					offset += 2;
 				}
 
+				offset += length;
+			} else {
 				offset += length;
 			}
 			break;

--- a/base/src/ipfix_message.c
+++ b/base/src/ipfix_message.c
@@ -236,7 +236,7 @@ int message_set_data(uint8_t *dest, uint8_t *source, int len)
 uint16_t get_next_data_record_offset(uint8_t *data_record, struct ipfix_template *tmplt)
 {
 	if (!tmplt) {
-		/* we don't have template for this data set */
+		/* We don't have a template for this data set */
 		return 0;
 	}
 
@@ -248,7 +248,6 @@ uint16_t get_next_data_record_offset(uint8_t *data_record, struct ipfix_template
 
 	index = count;
 
-	/* go over all fields */
 	while (count != tmplt->field_count) {
 		id = tmplt->fields[index].ie.id;
 		length = tmplt->fields[index].ie.length;
@@ -303,13 +302,11 @@ uint8_t **get_data_records(struct ipfix_data_set *data_set, struct ipfix_templat
 	}
 
 	min_record_length = tmplt->data_length;
-	offset = 0;
-
-	offset += 4;  /* size of the header */
+	offset = sizeof(struct ipfix_set_header);
 
 	if (min_record_length & 0x8000) {
 		/* oops, record contains fields with variable length */
-		min_record_length = min_record_length & 0x7fff; /* size of the fields, variable fields excluded  */
+		min_record_length = min_record_length & 0x7fff; /* Size of the fields, excluding variable-length fields */
 	}
 
 	while ((int) ntohs(data_set->header.length) - (int) offset - (int) min_record_length >= 0) {
@@ -321,7 +318,6 @@ uint8_t **get_data_records(struct ipfix_data_set *data_set, struct ipfix_templat
 
 	return records;
 }
-
 
 /**
  * \brief Create empty IPFIX message
@@ -350,7 +346,6 @@ struct ipfix_message *message_create_empty()
 
 	return message;
 }
-
 
 /**
  * \brief Dispose IPFIX message
@@ -384,7 +379,7 @@ int message_free(struct ipfix_message *msg)
  * \param[in] fields template (record) fields
  * \param[in] cnt number of fields
  * \param[in] enterprise enterprise field number
- * \param[in] id  field id
+ * \param[in] id field id
  * \param[out] data_offset offset data record specified by this template
  * \param[in] netw Flag indicating network byte order (template record)
  * \return pointer to row in fields
@@ -411,7 +406,7 @@ struct ipfix_template_row *fields_get_field(uint8_t *fields, int cnt, uint32_t e
 			ren = (netw) ? ntohl(*((uint32_t *) row)) : *((uint32_t *) row);
 		}
 		
-		/* Check informations */
+		/* Check field contents */
 		if (rid == id && ren == enterprise) {
 			if (ren != 0) {
 				--row;
@@ -419,7 +414,7 @@ struct ipfix_template_row *fields_get_field(uint8_t *fields, int cnt, uint32_t e
 			return row;
 		}
 
-		/* increase data offset */
+		/* Increase data offset */
 		if (data_offset) {
 			*data_offset += len;
 		}
@@ -643,8 +638,8 @@ int data_set_process_records(struct ipfix_data_set *data_set, struct ipfix_templ
 	uint32_t offset = 4;
 
 	if (min_record_length & 0x80000000) {
-		/* record contains fields with variable length */
-		min_record_length = min_record_length & 0x7fff; /* size of the fields, variable fields excluded  */
+		/* Record contains fields with variable length */
+		min_record_length = min_record_length & 0x7fff; /* Size of the fields, excluding variable-length fields */
 	}
 
 	while ((int) set_len - (int) offset - (int) min_record_length >= 0) {
@@ -706,8 +701,8 @@ void data_set_set_field(struct ipfix_data_set *data_set, struct ipfix_template *
 	uint32_t offset = 4;
 
 	if (min_record_length & 0x8000) {
-		/* record contains fields with variable length */
-		min_record_length = min_record_length & 0x7fff; /* size of the fields, variable fields excluded  */
+		/* Record contains fields with variable length */
+		min_record_length = min_record_length & 0x7fff; /* Size of the fields, excluding variable-length fields */
 	}
 
 	while ((int) setlen - (int) offset - (int) min_record_length >= 0) {

--- a/base/src/ipfix_message.c
+++ b/base/src/ipfix_message.c
@@ -424,6 +424,41 @@ struct ipfix_template_row *fields_get_field(uint8_t *fields, int cnt, uint32_t e
 }
 
 /**
+ * \brief Count the number of occurrences of the specified field
+ * \param[in] rec Template record
+ * \param[in] enterprise Field enterprise ID
+ * \param[in] id Field ID
+ * \return Number of field occurrences
+ */
+int template_record_count_field_occurences(struct ipfix_template_record *rec,
+        uint32_t enterprise, uint16_t id)
+{
+    int field_count = 0;
+    uint16_t total_field_count = ntohs(rec->count);
+    struct ipfix_template_row *row = (struct ipfix_template_row *) rec->fields;
+
+    int i;
+    for (i = 0; i < total_field_count; ++i, ++row) {
+        uint16_t rid = ntohs(row->id);
+        uint32_t ren = 0;
+
+        /* Get field ID and enterprise number */
+        if (rid >> 15) {
+            rid = rid & 0x7FFF;
+            ++row;
+            ren = ntohl(*((uint32_t *) row));
+        }
+
+        /* Check field contents */
+        if (rid == id && ren == enterprise) {
+            ++field_count;
+        }
+    }
+
+    return field_count;
+}
+
+/**
  * \brief Get template record field
  */
 struct ipfix_template_row *template_record_get_field(struct ipfix_template_record *rec, uint32_t enterprise, uint16_t id, int *data_offset)

--- a/base/src/template_manager.c
+++ b/base/src/template_manager.c
@@ -844,7 +844,7 @@ int template_contains_field(struct ipfix_template *templ, uint16_t field)
 	}
 
 	if (hit) {
-		return (!variable_length) ? total_length : 0;
+		return (variable_length) ? 0 : total_length;
 	}
 
 	/* Field could not be found in specific template */
@@ -1001,6 +1001,7 @@ int tm_compare_template_records(struct ipfix_template_record *first, struct ipfi
 	if (first->count != second->count) {
 		return 0;
 	}
+
 	uint16_t *field1 = (uint16_t *) first->fields;
 	uint16_t *field2 = (uint16_t *) second->fields;
 


### PR DESCRIPTION
The main purpose of this pull request is to start adding support for multi-instanced fields, i.e., multiple instances of the same field per template/data record. For example, the following methods were added:
* `template_record_count_field_occurences`: count number of instances of a particular field in a data record.
* `data_record_field_next_offset`: get offset of next field's instance. Note that `data_record_field_next_offset` is actually a generalization of the existing method `data_record_field_offset`. Compatibility with existing code should remain.

Includes various semantic and coding improvements as well.