### PR TITLE
Portability fix: data types and data type conversions

### DIFF
--- a/base/src/intermediate/filter/filter.c
+++ b/base/src/intermediate/filter/filter.c
@@ -991,23 +991,23 @@ struct filter_value *filter_parse_number(char *number)
 
 	/* Check suffix */
 	uint64_t tmp = strlen(number);
-	long mult = 1;
+	uint64_t mult = 1;
 	switch (number[tmp - 1]) {
 	case 'k':
 	case 'K':
-		mult = 1000;
+		mult = 1000ul;
 		break;
 	case 'm':
 	case 'M':
-		mult = 1000000;
+		mult = 1000000ul;
 		break;
 	case 'g':
 	case 'G':
-		mult = 1000000000;
+		mult = 1000000000ul;
 		break;
 	case 't':
 	case 'T':
-		mult = 1000000000000;
+		mult = 1000000000000ul;
 		break;
 	}
 

--- a/base/src/ipfixviewer/ipfixcol-ipfixviewer-output.c
+++ b/base/src/ipfixviewer/ipfixcol-ipfixviewer-output.c
@@ -374,7 +374,7 @@ static uint16_t print_data_record(uint8_t *data_record, struct ipfix_template *t
 			offset += 4;
 			break;
 		case (8):
-			printf("Value: %#lx\n", read64(data_record+offset));
+			printf("Value: %#" PRIx64 "\n", read64(data_record+offset));
 			offset += 8;
 			break;
 		default:

--- a/base/src/output_manager.c
+++ b/base/src/output_manager.c
@@ -785,11 +785,11 @@ static void *statistics_thread(void* config)
 			delta_lost_data_records = aux_node->input_info->sequence_number - aux_node->input_info->data_records - aux_node->last_lost_data_records;
 
 			if (print_stat_to_file) {
-				fprintf(stat_out_file, "%s_%u=%lu\n", "PACKETS",
+				fprintf(stat_out_file, "%s_%u=%" PRIu64 "\n", "PACKETS",
 						aux_node->input_info->odid, aux_node->input_info->packets);
-				fprintf(stat_out_file, "%s_%u=%lu\n", "DATA_REC",
+				fprintf(stat_out_file, "%s_%u=%" PRIu64 "\n", "DATA_REC",
 						aux_node->input_info->odid, aux_node->input_info->data_records);
-				fprintf(stat_out_file, "%s_%u=%lu\n", "LOST_DATA_REC",
+				fprintf(stat_out_file, "%s_%u=%" PRIu64 "\n", "LOST_DATA_REC",
 						aux_node->input_info->odid, aux_node->input_info->sequence_number - aux_node->input_info->data_records);
 				fprintf(stat_out_file, "%s_%u=%u\n", "PACKETS_SEC",
 						aux_node->input_info->odid, delta_packets / conf->stat_interval);

--- a/base/src/utils/profiles/filter.c
+++ b/base/src/utils/profiles/filter.c
@@ -622,23 +622,23 @@ struct filter_value *filter_parse_number(char *number)
 
 	/* Check suffix */
 	uint64_t tmp = strlen(number);
-	long mult = 1;
+	uint64_t mult = 1;
 	switch (number[tmp - 1]) {
 	case 'k':
 	case 'K':
-		mult = 1000;
+		mult = 1000ul;
 		break;
 	case 'm':
 	case 'M':
-		mult = 1000000;
+		mult = 1000000ul;
 		break;
 	case 'g':
 	case 'G':
-		mult = 1000000000;
+		mult = 1000000000ul;
 		break;
 	case 't':
 	case 'T':
-		mult = 1000000000000;
+		mult = 1000000000000ul;
 		break;
 	}
 


### PR DESCRIPTION
-fixes based on GCC warnings on 32bit ARMv7
-long int was too small for integer constant on 32bit architecture
-exact-width integer types have to be coverted using macros defined in
 inttypes.h (PRIu64, PRIx32, ...)