### PR TITLE
IPFIXcol: add support for pidfile

### DIFF
--- a/base/documentation/man/ipfixcol.dbk
+++ b/base/documentation/man/ipfixcol.dbk
@@ -53,6 +53,7 @@
             <arg>-dhVs</arg>
             <arg>-v level</arg>
             <arg>-S time</arg>
+            <arg>-p file</arg>
         </cmdsynopsis>
     </refsynopsisdiv>
 
@@ -146,6 +147,15 @@
 				<listitem>
 					<simpara>
 						Print proccessing statistics every <replaceable class="parameter">time</replaceable> seconds.
+					</simpara>
+				</listitem>
+			</varlistentry>
+
+                        <varlistentry>
+				<term>-p <replaceable class="parameter">file</replaceable></term>
+				<listitem>
+					<simpara>
+						Path to the pidfile. Without this option, no pidfile is created.
 					</simpara>
 				</listitem>
 			</varlistentry>

--- a/plugins/storage/lnfstore/ipfixcol-lnfstore-output.dbk
+++ b/plugins/storage/lnfstore/ipfixcol-lnfstore-output.dbk
@@ -110,7 +110,7 @@
 				<varlistentry>
 					<term><command>storagePath</command></term>
 					<listitem>
-						<simpara>The path element specifies the storage directory for data collected by the lnfstore plugin.</simpara>
+						<simpara>The path element specifies the storage directory for data collected by the lnfstore plugin. Path may contain special character sequences, each of which is introduced by a "%" character and terminated by some other character. Each of this sequences is substituted by its value. Currenly supported special characters: %h = hostname.</simpara>
 					</listitem>
 				</varlistentry>
 


### PR DESCRIPTION
New argument option -p FILE will cause creation of FILE with all PIDs
written in it in a textual representation separated by new line. This
FILE will be deleted (unlinked) during termination.