### PR TITLE
fbitdump: add text IE to arg for plugins

### DIFF
--- a/tools/fbitdump/src/Printer.cpp
+++ b/tools/fbitdump/src/Printer.cpp
@@ -195,7 +195,7 @@ const std::string Printer::printValue(const Column *col, const Cursor *cur) cons
 	std::string valueStr;
 
 	if (!col->getSemantics().empty() && (col->getSemantics() != "flows") && (col->format != NULL)) {
-		plugin_arg_t arg = {.type = val->type, .val = (const plugin_arg_val *) val->value};
+		plugin_arg_t arg = {.type = val->type, .val = (const plugin_arg_val *) val->value, .text = val->string.c_str()};
 		col->format(&arg, (int) this->conf.getPlainNumbers(col->getSemantics()), plugin_buffer, col->pluginConf);
 		valueStr.append(plugin_buffer);
 	} else {

--- a/tools/fbitdump/src/plugins/plugin_header.h
+++ b/tools/fbitdump/src/plugins/plugin_header.h
@@ -25,43 +25,44 @@ union plugin_arg_val
 
 
 typedef struct {
-    int type;
-    const union plugin_arg_val *val;
+	int type;
+	const union plugin_arg_val *val;
+	const char *text;
 } plugin_arg_t;
 
 
 enum val_type {
-    UNKNOWN = 0,
-    /// A special eight-byte ID type for internal use.
-    OID,
-    INT8,	///!< One-byte signed integers, internally char.
-    UINT8,	///!< One-byte unsigned integers, internally unsigned char.
-    INT16,	///!< Two-byte signed integers, internally int16_t.
-    UINT16, ///!< Two-byte unsigned integers, internally uint16_t.
-    INT32,	///!< Four-byte signed integers, internally int32_t.
-    UINT32,	///!< Four-byte unsigned integers, internally uint32_t.
-    INT64,	///!< Eight-byte signed integers, internally int64_t.
-    UINT64,	///!< Eight-byte unsigned integers, internally uint64_t.
-    FLOAT,	///!< Four-byte IEEE floating-point numbers, internally float.
-    DOUBLE, ///!< Eight-byte IEEE floating-point numbers, internally double.
-    /// Low cardinality null-terminated strings.  Strings are
-    /// internally stored with the null terminators.  Each string value
-    /// is intended to be treated as a single atomic item.
-    CATEGORY,
-    /// Arbitrary null-terminated strings.  Strings are internally
-    /// stored with the null terminators.  Each string could be further
-    /// broken into tokens for a full-text index known as keyword
-    /// index.  Could search for presence of some keywords through
-    /// expression "contains" such as "contains(textcolumn, 'Berkeley',
-    /// 'California')".
-    TEXT,
-    /// Byte array.  Also known as Binary Large Objects (blob) or
-    /// opaque objects.  A column of this type requires special
-    /// handling for input and output.  It can not be used as a part of
-    /// any searching criteria.
-    BLOB,
-    /// User-defined type.  FastBit does not know much about it.
-    UDT
+	UNKNOWN = 0,
+	/// A special eight-byte ID type for internal use.
+	OID,
+	INT8,	///!< One-byte signed integers, internally char.
+	UINT8,	///!< One-byte unsigned integers, internally unsigned char.
+	INT16,	///!< Two-byte signed integers, internally int16_t.
+	UINT16, ///!< Two-byte unsigned integers, internally uint16_t.
+	INT32,	///!< Four-byte signed integers, internally int32_t.
+	UINT32,	///!< Four-byte unsigned integers, internally uint32_t.
+	INT64,	///!< Eight-byte signed integers, internally int64_t.
+	UINT64,	///!< Eight-byte unsigned integers, internally uint64_t.
+	FLOAT,	///!< Four-byte IEEE floating-point numbers, internally float.
+	DOUBLE, ///!< Eight-byte IEEE floating-point numbers, internally double.
+	/// Low cardinality null-terminated strings.  Strings are
+	/// internally stored with the null terminators.  Each string value
+	/// is intended to be treated as a single atomic item.
+	CATEGORY,
+	/// Arbitrary null-terminated strings.  Strings are internally
+	/// stored with the null terminators.  Each string could be further
+	/// broken into tokens for a full-text index known as keyword
+	/// index.  Could search for presence of some keywords through
+	/// expression "contains" such as "contains(textcolumn, 'Berkeley',
+	/// 'California')".
+	TEXT,
+	/// Byte array.  Also known as Binary Large Objects (blob) or
+	/// opaque objects.  A column of this type requires special
+	/// handling for input and output.  It can not be used as a part of
+	/// any searching criteria.
+	BLOB,
+	/// User-defined type.  FastBit does not know much about it.
+	UDT
 };
 
 /**


### PR DESCRIPTION
Fbitdump plugins should now have access to variable length / string IE.