### PR TITLE
FastBit storage: Support for using ipfix-elements.xml data lengths instead of template lengths

### DIFF
--- a/plugins/storage/fastbit/config_struct.h
+++ b/plugins/storage/fastbit/config_struct.h
@@ -58,12 +58,14 @@ struct fastbit_config {
 	/* Stores data buffers based on received templates
 	 * (observation IDs -> template ID -> template data)
 	 */
+	std::map<uint32_t, std::map<uint16_t, template_table*>*> *ob_dom;
 
-	std::map<uint32_t,FlowWatch> *flowWatch;
+	std::map<uint32_t, FlowWatch> *flowWatch;
 
 	/* Element types from ipfix-elements.xml is loaded into elements_types
 	 * (Enterprise ID -> element ID -> element storage type)
 	 */
+	std::map<uint32_t, std::map<uint16_t, enum store_type>> *elements_types;
 
 	/* Stores elements that should be indexed */
 	std::vector<std::string> *index_en_id;

--- a/plugins/storage/fastbit/config_struct.h
+++ b/plugins/storage/fastbit/config_struct.h
@@ -55,59 +55,61 @@ extern "C" {
 class template_table;
 
 struct fastbit_config {
-	/*ob_dom stores data buffers based on received templates
-	 * (observation ids -> template id -> template data */
-	std::map<uint32_t,std::map<uint16_t,template_table*>* > *ob_dom;
+	/* Stores data buffers based on received templates
+	 * (observation IDs -> template ID -> template data)
+	 */
 
 	std::map<uint32_t,FlowWatch> *flowWatch;
 
-	/* element info from ipfix-elements.xml is loaded into elements_types
-	 * (Enterprise id -> element id -> element storage type) */
-	std::map<uint32_t,std::map<uint16_t,enum store_type> > *elements_types;
+	/* Element types from ipfix-elements.xml is loaded into elements_types
+	 * (Enterprise ID -> element ID -> element storage type)
+	 */
 
-	/* index_en_id stores elements which should be indexed.
-	 * elements stored as column names ('e0id4') */
+	/* Stores elements that should be indexed */
 	std::vector<std::string> *index_en_id;
 
-	/* directories for index & reorder thread */
+	/* Directories for index & reorder thread */
 	std::vector<std::string> *dirs;
 
-	/* time_window specifies time interval for storage directory rotation
-	 * (0 = no time based rotation ) */
+	/* Specifies time interval for storage directory rotation
+	 * (0 = no time based rotation)
+	 */
 	int time_window;
 
-	/* records_window specifies record count for storage directory rotation
-	 * (0 = no record based rotation ) */
+	/* Specifies record count for storage directory rotation
+	 * (0 = no record based rotation)
+	 */
 	int records_window;
 
-	bool new_dir; /** Is current directory a new one? */
+	bool new_dir; /* Is current directory a new one? */
 
-	/* hold type of name strategy for storage directory rotation */
+	/* Holds type of name strategy for storage directory rotation */
 	enum name_type dump_name;
 
-	/* path to directory where should be storage directory flushed */
+	/* Path to directory where should be storage directory flushed */
 	std::string sys_dir;
 
-	/* current window directory */
+	/* Current window directory */
 	std::string window_dir;
 
-	/* user prefix for storage directory */
+	/* User prefix for storage directory */
 	std::string prefix;
 
-	/* time of last flush (used for time based rotation,
-	 * name is based on start of interval not its end!) */
+	/* Time of last flush, used for time based rotation.
+	 * Name is based on start of interval, not its end.
+	 */
 	time_t last_flush;
 
-	/* specifies if stored data should be reordered */
-	int reorder;
+	/* Specifies whether stored data should be reordered */
+	bool reorder;
 
-	/* specifies if indexes should be build during storage.
-	 * 0 = no indexes, 1 = index all, 2 = index only marked elements */
+	/* Specifies whether indexes should be build during storage.
+	 * 0 = no indexes, 1 = index all, 2 = index only marked elements
+	 */
 	int indexes;
 
-	/* specifices whether .sp files should be created.
-	 * 0 = don't create .sp files, 1 = create .sp files */
-	int create_sp_files;
+	/* Specifices whether .sp files should be created */
+	bool create_sp_files;
 
 	/* size of buffer (number of values)*/
 	int buff_size;

--- a/plugins/storage/fastbit/config_struct.h
+++ b/plugins/storage/fastbit/config_struct.h
@@ -67,6 +67,11 @@ struct fastbit_config {
 	 */
 	std::map<uint32_t, std::map<uint16_t, enum store_type>> *elements_types;
 
+	/* Element lengths from ipfix-elements.xml is loaded into elements_lengths
+	 * (Enterprise ID -> element ID -> element storage type)
+	 */
+	std::map<uint32_t, std::map<uint16_t, int>> *elements_lengths;
+
 	/* Stores elements that should be indexed */
 	std::vector<std::string> *index_en_id;
 

--- a/plugins/storage/fastbit/config_struct.h
+++ b/plugins/storage/fastbit/config_struct.h
@@ -118,6 +118,9 @@ struct fastbit_config {
 	/* Specifices whether .sp files should be created */
 	bool create_sp_files;
 
+	/* Specifies whether field lengths should be taken from template or ipfix-elements.xml */
+	bool use_template_field_lengths;
+
 	/* size of buffer (number of values)*/
 	int buff_size;
 

--- a/plugins/storage/fastbit/fastbit.cpp
+++ b/plugins/storage/fastbit/fastbit.cpp
@@ -218,7 +218,8 @@ int process_startup_xml(char *params, struct fastbit_config* c)
 {
 	struct tm *timeinfo;
 	char formated_time[17];
-	std::string path, time_window, record_limit, name_type, name_prefix, indexes, create_sp_files, test, time_alignment;
+	std::string path, time_window, record_limit, name_type, name_prefix,
+			indexes, reorder, create_sp_files, test, template_field_lengths, time_alignment;
 	pugi::xml_document doc;
 	doc.load(params);
 
@@ -480,7 +481,7 @@ int store_packet(void *config, const struct ipfix_message *ipfix_msg,
 		/* Should we create new window?  */
 		if (conf->records_window != 0 && rcnt > conf->records_window) {
 			/* Flush data for all ODID */
-			for (dom_id = ob_dom->begin(); dom_id!=ob_dom->end(); dom_id++) {
+			for (dom_id = ob_dom->begin(); dom_id != ob_dom->end(); dom_id++) {
 				flush_data(conf, (*dom_id).first, (*dom_id).second, false);
 			}
 

--- a/plugins/storage/fastbit/fastbit.cpp
+++ b/plugins/storage/fastbit/fastbit.cpp
@@ -261,7 +261,7 @@ int process_startup_xml(char *params, struct fastbit_config* c)
 			}
 
 			/* Make sure IPv6 elements are indexed */
-			if (IPv6 == get_type_from_xml(c, strtoul(en.c_str(), NULL, 0), strtoul(id.c_str(), NULL, 0))) {
+			if (IPV6 == get_type_from_xml(c, strtoul(en.c_str(), NULL, 0), strtoul(id.c_str(), NULL, 0))) {
 				c->index_en_id->push_back("e" + en + "id" + id + "p0");
 				c->index_en_id->push_back("e" + en + "id" + id + "p1");
 			} else {

--- a/plugins/storage/fastbit/fastbit.cpp
+++ b/plugins/storage/fastbit/fastbit.cpp
@@ -79,7 +79,7 @@ void *reorder_index(void *config)
 	for (unsigned int i = 0; i < conf->dirs->size(); i++) {
 		dir = (*conf->dirs)[i];
 		/* Reorder partitions */
-		if (conf->reorder == 1) {
+		if (conf->reorder) {
 			MSG_DEBUG(msg_module, "Reordering: %s",dir.c_str());
 			reorder_part = new ibis::part(dir.c_str(), NULL, false);
 			reorder_part->reorder(); /* TODO return value */
@@ -238,23 +238,14 @@ int process_startup_xml(char *params, struct fastbit_config* c)
 			c->sys_dir = path;
 		}
 
-		c->indexes = 0;
 		indexes = ie.node().child_value("onTheFlyIndexes");
-		if (indexes == "yes") {
-			c->indexes = 1;
-		}
+		c->indexes = (indexes == "yes");
 
-		c->create_sp_files = 0;
 		create_sp_files = ie.node().child_value("createSpFiles");
-		if (create_sp_files == "yes") {
-			c->create_sp_files = 1;
-		}
+		c->create_sp_files = (create_sp_files == "yes");
 
-		c->reorder = 0;
-		indexes = ie.node().child_value("reorder");
-		if (indexes == "yes") {
-			c->reorder = 1;
-		}
+		reorder = ie.node().child_value("reorder");
+		c->reorder = (reorder == "yes");
 
 		pugi::xpath_node_set index_e = doc.select_nodes("fileWriter/indexes/element");
 		for (pugi::xpath_node_set::const_iterator it = index_e.begin(); it != index_e.end(); ++it) {

--- a/plugins/storage/fastbit/fastbit.cpp
+++ b/plugins/storage/fastbit/fastbit.cpp
@@ -248,6 +248,9 @@ int process_startup_xml(char *params, struct fastbit_config* c)
 		reorder = ie.node().child_value("reorder");
 		c->reorder = (reorder == "yes");
 
+		template_field_lengths = ie.node().child_value("useTemplateFieldLengths");
+		c->use_template_field_lengths = (!ie.node().child("useTemplateFieldLengths") || template_field_lengths == "yes");
+
 		pugi::xpath_node_set index_e = doc.select_nodes("fileWriter/indexes/element");
 		for (pugi::xpath_node_set::const_iterator it = index_e.begin(); it != index_e.end(); ++it) {
 			pugi::xpath_node node = *it;

--- a/plugins/storage/fastbit/fastbit.cpp
+++ b/plugins/storage/fastbit/fastbit.cpp
@@ -360,6 +360,12 @@ int storage_init(char *params, void **config)
 		return 1;
 	}
 
+	c->elements_lengths = new std::map<uint32_t, std::map<uint16_t, int>>;
+	if (c->elements_lengths == NULL) {
+		MSG_ERROR(msg_module, "Memory allocation failed (%s:%d)", __FILE__, __LINE__);
+		return 1;
+	}
+
 	c->index_en_id = new std::vector<std::string>;
 	if (c->index_en_id == NULL) {
 		MSG_ERROR(msg_module, "Memory allocation failed (%s:%d)", __FILE__, __LINE__);
@@ -570,6 +576,7 @@ int storage_close(void **config)
 	delete conf->dirs;
 	delete conf->flowWatch;
 	delete conf->elements_types;
+	delete conf->elements_lengths;
 	delete conf;
 	return 0;
 }

--- a/plugins/storage/fastbit/fastbit.h
+++ b/plugins/storage/fastbit/fastbit.h
@@ -61,9 +61,9 @@ const unsigned int RESERVED_SPACE = 75000;
 #define msg_module "fastbit storage"
 
 /* this enum specifies types of file naming strategy */
-enum name_type {TIME,INCREMENTAL,PREFIX};
+enum name_type { TIME, INCREMENTAL, PREFIX };
 
 /* this enum specifies types of elements */
-enum store_type {UINT,INT,BLOB,TEXT,FLOAT,IPv6,UNKNOWN};
+enum store_type { UINT, INT, BLOB, TEXT, FLOAT, IPV6, UNKNOWN };
 
 #endif /* FASTBIT_H_ */

--- a/plugins/storage/fastbit/fastbit_element.cpp
+++ b/plugins/storage/fastbit/fastbit_element.cpp
@@ -54,6 +54,7 @@ int load_types_from_xml(struct fastbit_config *conf)
 	pugi::xml_parse_result result;
 	uint32_t en;
 	uint16_t id;
+	int len;
 	enum store_type type;
 	std::string str_value;
 
@@ -109,6 +110,39 @@ int load_types_from_xml(struct fastbit_config *conf)
 		}
 
 		(*conf->elements_types)[en][id] = type;
+
+		/* Obtain field length */
+		if (str_value == "unsigned64" \
+				or str_value == "dateTimeMilliseconds" \
+				or str_value == "dateTimeMicroseconds" \
+				or str_value == "dateTimeNanoseconds" \
+				or str_value == "macAddress" \
+				or str_value == "float64" \
+				or str_value == "signed64") {
+			len = 8;
+		} else if (str_value == "unsigned32" \
+				or str_value == "dateTimeSeconds" \
+				or str_value == "ipv4Address" \
+				or str_value == "boolean" \
+				or str_value == "float32" \
+				or str_value == "signed32") {
+			len = 4;
+		} else if (str_value == "unsigned16" \
+				or str_value == "signed16") {
+			len = 2;
+		} else if (str_value == "unsigned8" \
+				or str_value == "signed8") {
+			len = 1;
+		} else if (str_value == "ipv6Address" \
+				or str_value == "string" \
+				or str_value == "octetArray" \
+				or str_value == "basicList" \
+				or str_value == "subTemplateList" \
+				or str_value == "subTemplateMultiList") {
+			len = -1;
+		}
+
+		(*conf->elements_lengths)[en][id] = len;
 	}
 
 	return 0;

--- a/plugins/storage/fastbit/fastbit_element.cpp
+++ b/plugins/storage/fastbit/fastbit_element.cpp
@@ -72,22 +72,37 @@ int load_types_from_xml(struct fastbit_config *conf)
 		en = strtoul(str_value.c_str(), NULL, 0);
 		str_value = it->node().child_value("id");
 		id = strtoul(str_value.c_str(), NULL, 0);
-
 		str_value = it->node().child_value("dataType");
 
-		if (str_value == "unsigned8" or str_value == "unsigned16" or str_value == "unsigned32" or str_value == "unsigned64" or \
-				str_value == "dateTimeSeconds" or str_value == "dateTimeMilliseconds" or str_value == "dateTimeMicroseconds" or \
-				str_value == "dateTimeNanoseconds" or str_value == "ipv4Address" or str_value == "macAddress" or str_value == "boolean") {
+		/* Obtain field type */
+		if (str_value == "boolean" \
+				or str_value == "dateTimeSeconds" \
+				or str_value == "dateTimeMicroseconds" \
+				or str_value == "dateTimeMilliseconds" \
+				or str_value == "dateTimeNanoseconds" \
+				or str_value == "ipv4Address" \
+				or str_value == "macAddress" \
+				or str_value == "unsigned8" \
+				or str_value == "unsigned16" \
+				or str_value == "unsigned32" \
+				or str_value == "unsigned64") {
 			type = UINT;
-		} else if (str_value == "signed8" or str_value == "signed16" or str_value == "signed32" or str_value == "signed64") {
+		} else if (str_value == "signed8" \
+				or str_value == "signed16" \
+				or str_value == "signed32" \
+				or str_value == "signed64") {
 			type = INT;
 		} else if (str_value == "ipv6Address") {
-			type = IPv6;
-		} else if (str_value == "float32" or str_value == "float64") {
+			type = IPV6;
+		} else if (str_value == "float32" \
+			or str_value == "float64") {
 			type = FLOAT;
 		} else if (str_value == "string") {
 			type = TEXT;
-		} else if (str_value == "octetArray" or str_value == "basicList" or str_value == "subTemplateList" or str_value== "subTemplateMultiList") {
+		} else if (str_value == "octetArray" \
+				or str_value == "basicList" \
+				or str_value == "subTemplateList" \
+				or str_value== "subTemplateMultiList") {
 			type = BLOB;
 		} else {
 			type = UNKNOWN;
@@ -169,19 +184,19 @@ int element::flush(std::string path)
 	if (_filled > 0) {
 		f = fopen((path + "/" + _name).c_str(), "a+");
 		if (f == NULL) {
-			fprintf(stderr, "Error while writing data (fopen)\n");
+			MSG_ERROR(msg_module, "Error while writing data (fopen)");
 			return 1;
 		}
 
 		if (_buffer == NULL) {
-			fprintf(stderr, "Error while writing data (buffer)\n");
+			MSG_ERROR(msg_module, "Error while writing data (buffer)");
 			fclose(f);
 			return 1;
 		}
 
 		check = fwrite(_buffer, size(), _filled, f);
 		if (check != (size_t) _filled) {
-			fprintf(stderr, "Error while writing data (fwrite)\n");
+			MSG_ERROR(msg_module, "Error while writing data (fwrite)");
 			fclose(f);
 			return 1;
 		}
@@ -256,12 +271,12 @@ uint16_t el_float::fill(uint8_t *data)
 	switch(_size) {
 	case 4:
 		/* float32 */
-		*((uint32_t*)&(float_value.float32)) = ntohl(*((uint32_t*) data));
+		*((uint32_t*) &(float_value.float32)) = ntohl(*((uint32_t*) data));
 		this->append(&(float_value.float32));
 		break;
 	case 8:
 		/* float64 */
-		*((uint64_t*)&(float_value.float64)) = be64toh(*((uint64_t*) data));
+		*((uint64_t*) &(float_value.float64)) = be64toh(*((uint64_t*) data));
 		this->append(&(float_value.float64));
 		break;
 	default:
@@ -304,7 +319,7 @@ el_text::el_text(int size, uint32_t en, uint16_t id, uint32_t buf_size, struct f
 	_sp_buffer_size = 0;
 	_sp_buffer_offset = 0;
 
-	if (size == VAR_IE_LENGTH) { // Element with variable size
+	if (size == VAR_IE_LENGTH) { /* Element with variable size */
 		_var_size = true;
 	}
 
@@ -317,7 +332,7 @@ el_text::el_text(int size, uint32_t en, uint16_t id, uint32_t buf_size, struct f
 
 	allocate_buffer(buf_size);
 
-	/* Allocate the sp buffer, if enabled in config */
+	/* Allocate sp buffer, if enabled in config */
 	if (_config->create_sp_files) {
 		_sp_buffer_size = buf_size;
 		_sp_buffer = (char *) realloc(_sp_buffer, _sp_buffer_size);
@@ -335,7 +350,7 @@ el_text::el_text(int size, uint32_t en, uint16_t id, uint32_t buf_size, struct f
 int el_text::append_str(void *data, int size)
 {
 	/* Check buffer space */
-	if (_filled + size + 1 >= _buf_max) { // 1 = terminating zero
+	if (_filled + size + 1 >= _buf_max) { /* 1 = terminating zero */
 		_buf_max = _buf_max + (100 * size) + 1; // TODO
 		_buffer = (char *) realloc(_buffer, _size * _buf_max);
 	}
@@ -367,7 +382,7 @@ uint16_t el_text::fill(uint8_t *data)
 	this->append_str(&(data[_offset]), _true_size);
 
 	if (_config->create_sp_files) {
-		/* Check that the sp buffer is big enough */
+		/* Check whether sp buffer is large enough */
 		if (_sp_buffer_offset + 8 >= _sp_buffer_size) {
 			_sp_buffer_size *= 2; /* Double the buffer */
 			_sp_buffer = (char *) realloc(_sp_buffer, _sp_buffer_size);
@@ -377,7 +392,7 @@ uint16_t el_text::fill(uint8_t *data)
 			}
 		}
 
-		/* Update the sp buffer */
+		/* Update sp buffer */
 		*(uint64_t *) (_sp_buffer + _sp_buffer_offset) = (uint64_t) _filled;
 		_sp_buffer_offset += 8;
 	}
@@ -483,7 +498,7 @@ el_blob::el_blob(int size, uint32_t en, uint16_t id, uint32_t buf_size):
 
 	allocate_buffer(buf_size);
 
-	/* Allocate the sp buffer */
+	/* Allocate sp buffer */
 	_sp_buffer_size = buf_size;
 	_sp_buffer = (char *) realloc(_sp_buffer, _sp_buffer_size);
 	if (_sp_buffer == NULL) {
@@ -516,7 +531,7 @@ uint16_t el_blob::fill(uint8_t *data)
 	}
 
 	if (_filled + _true_size >= _buf_max) {
-		_buf_max += 100 * _true_size; // TODO find some better constant
+		_buf_max += 100 * _true_size; /* TODO find some better constant */
 		_buffer = (char *) realloc(_buffer, _buf_max);
 		if (_buffer == NULL) {
 			perror("realloc blob buffer");
@@ -529,9 +544,9 @@ uint16_t el_blob::fill(uint8_t *data)
 	/* Update the number of filled bytes */
 	_filled += _true_size;
 
-	/* Check that the sp buffer is big enough */
+	/* Check whether sp buffer is large enough */
 	if (_sp_buffer_offset + 8 >= _sp_buffer_size) {
-		_sp_buffer_size *= 2; /* Double the buffer */
+		_sp_buffer_size *= 2; /* Double buffer size */
 		_sp_buffer = (char *) realloc(_sp_buffer, _sp_buffer_size);
 		if (_sp_buffer == NULL) {
 			perror("realloc blob sp buffer");
@@ -539,7 +554,7 @@ uint16_t el_blob::fill(uint8_t *data)
 		}
 	}
 
-	/* Update the sp buffer */
+	/* Update sp buffer */
 	*(uint64_t *) (_sp_buffer + _sp_buffer_offset) = (uint64_t) _filled;
 	_sp_buffer_offset += 8;
 
@@ -600,7 +615,7 @@ el_uint::el_uint(int size, uint32_t en, uint16_t id, uint32_t buf_size)
 	this->set_type();
 
 	if (buf_size == 0) {
-		 buf_size = RESERVED_SPACE;
+		buf_size = RESERVED_SPACE;
 	}
 
 	allocate_buffer(buf_size);
@@ -608,6 +623,7 @@ el_uint::el_uint(int size, uint32_t en, uint16_t id, uint32_t buf_size)
 
 uint16_t el_uint::fill(uint8_t *data) {
 	uint_value.ulong = 0;
+
 	switch(_real_size) {
 	case 1:
 		/* ubyte */
@@ -620,7 +636,7 @@ uint16_t el_uint::fill(uint8_t *data) {
 		this->append(&(uint_value.ushort));
 		break;
 	case 3:
-		byte_reorder((uint8_t *) &(uint_value.uint),data,_real_size, sizeof(uint));
+		byte_reorder((uint8_t *) &(uint_value.uint), data, _real_size, sizeof(uint));
 		this->append(&(uint_value.uint));
 		break;
 	case 4:
@@ -631,7 +647,7 @@ uint16_t el_uint::fill(uint8_t *data) {
 	case 5:
 	case 6:
 	case 7:
-		byte_reorder((uint8_t *) &(uint_value.ulong),data,_real_size, sizeof(ulong));
+		byte_reorder((uint8_t *) &(uint_value.ulong), data, _real_size, sizeof(ulong));
 		this->append(&(uint_value.ulong));
 		break;
 	case 8:

--- a/plugins/storage/fastbit/fastbit_element.cpp
+++ b/plugins/storage/fastbit/fastbit_element.cpp
@@ -250,13 +250,17 @@ std::string element::get_part_info()
 		+ "END Column\n";
 }
 
-el_var_size::el_var_size(int size, uint32_t en, uint16_t id, uint32_t buf_size)
+el_var_size::el_var_size(int size, uint32_t en, uint16_t id, uint32_t buf_size, struct fastbit_config *config)
 {
 	(void) buf_size;
-	data = NULL;
+
+	_config = config;
+	_en = en;
+	_id = id;
 	_size = size;
 	_filled = 0;
 	_buffer = NULL;
+	data = NULL;
 
 	set_name(en, id);
 	this->set_type();
@@ -284,8 +288,11 @@ int el_var_size::set_type()
 	return 0;
 }
 
-el_float::el_float(int size, uint32_t en, uint16_t id, uint32_t buf_size)
+el_float::el_float(int size, uint32_t en, uint16_t id, uint32_t buf_size, struct fastbit_config *config)
 {
+	_config = config;
+	_en = en;
+	_id = id;
 	_size = size;
 	_filled = 0;
 	_buffer = NULL;
@@ -344,8 +351,9 @@ el_text::el_text(int size, uint32_t en, uint16_t id, uint32_t buf_size, struct f
 	_var_size(false), _true_size(size), _sp_buffer(NULL)
 {
 	_config = config;
-
-	_size = 1; // Size for flush function
+	_en = en;
+	_id = id;
+	_size = 1; /* Size for flush function */
 	_offset = 0;
 	_filled = 0;
 	_buffer = NULL;
@@ -478,12 +486,15 @@ el_text::~el_text()
 	free(_sp_buffer);
 }
 
-el_ipv6::el_ipv6(int size, uint32_t en, uint16_t id, int part, uint32_t buf_size)
+el_ipv6::el_ipv6(int size, uint32_t en, uint16_t id, int part, uint32_t buf_size, struct fastbit_config *config)
 {
-	ipv6_value = 0;
+	_config = config;
+	_en = en;
+	_id = id;
 	_size = size;
 	_filled = 0;
 	_buffer = NULL;
+	ipv6_value = 0;
 
 	set_name(en, id, part);
 	this->set_type();
@@ -510,10 +521,12 @@ int el_ipv6::set_type()
 	return 0;
 }
 
-el_blob::el_blob(int size, uint32_t en, uint16_t id, uint32_t buf_size):
+el_blob::el_blob(int size, uint32_t en, uint16_t id, uint32_t buf_size, struct fastbit_config *config):
 	_var_size(false), _true_size(size), _sp_buffer(NULL)
 {
-	/* Set variables defined in parent */
+	_config = config;
+	_en = en;
+	_id = id;
 	_size = 1; /* This is size for flush function */
 	_buffer = NULL;
 	_filled = 0;
@@ -638,8 +651,11 @@ el_blob::~el_blob()
 	free(_sp_buffer);
 }
 
-el_uint::el_uint(int size, uint32_t en, uint16_t id, uint32_t buf_size)
+el_uint::el_uint(int size, uint32_t en, uint16_t id, uint32_t buf_size, struct fastbit_config *config)
 {
+	_config = config;
+	_en = en;
+	_id = id;
 	_real_size = size;
 	_size = 0;
 	_filled = 0;
@@ -769,8 +785,11 @@ int el_sint::set_type()
 	return 0;
 }
 
-el_sint::el_sint(int size, uint32_t en, uint16_t id, uint32_t buf_size)
+el_sint::el_sint(int size, uint32_t en, uint16_t id, uint32_t buf_size, struct fastbit_config *config)
 {
+	_config = config;
+	_en = en;
+	_id = id;
 	_real_size = size;
 	_size = 0;
 	_filled = 0;
@@ -786,12 +805,14 @@ el_sint::el_sint(int size, uint32_t en, uint16_t id, uint32_t buf_size)
 	allocate_buffer(buf_size);
 }
 
-el_unknown::el_unknown(int size, uint32_t en, uint16_t id, int part, uint32_t buf_size)
+el_unknown::el_unknown(int size, uint32_t en, uint16_t id, int part, uint32_t buf_size, struct fastbit_config *config)
 {
-	(void) en;
-	(void) id;
 	(void) part;
 	(void) buf_size;
+
+	_config = config;
+	_en = en;
+	_id = id;
 
 	_size = size;
 	_name[0] = '\0';

--- a/plugins/storage/fastbit/fastbit_element.cpp
+++ b/plugins/storage/fastbit/fastbit_element.cpp
@@ -700,35 +700,34 @@ uint16_t el_uint::fill(uint8_t *data) {
 
 int el_uint::set_type()
 {
-	switch(_real_size) {
-	case 1:
-		/* ubyte */
-		_type = ibis::UBYTE;
-		_size = 1;
-		break;
-	case 2:
-		/* ushort */
-		_type = ibis::USHORT;
-		_size = 2;
-		break;
-	case 3:
-	case 4:
-		/* uint */
-		_type = ibis::UINT;
-		_size = 4;
-		break;
-	case 5:
-	case 6:
-	case 7:
-	case 8:
-		/* ulong */
-		_type = ibis::ULONG;
-		_size = 8;
-		break;
-	default:
-		MSG_ERROR(msg_module, "Invalid element size (%s - %u)", _name, _size);
-		return 1;
-		break;
+	int target_size = (_config->use_template_field_lengths) ?
+			_real_size : (*_config->elements_lengths)[_en][_id];
+
+	switch(target_size) {
+		case 1:
+			_type = ibis::UBYTE;
+			_size = 1;
+			break;
+		case 2:
+			_type = ibis::USHORT;
+			_size = 2;
+			break;
+		case 3:
+		case 4:
+			_type = ibis::UINT;
+			_size = 4;
+			break;
+		case 5:
+		case 6:
+		case 7:
+		case 8:
+			_type = ibis::ULONG;
+			_size = 8;
+			break;
+		default:
+			MSG_ERROR(msg_module, "Invalid element size (%s - %u)", _name, _size);
+			return 1;
+			break;
 	}
 
 	return 0;

--- a/plugins/storage/fastbit/fastbit_element.cpp
+++ b/plugins/storage/fastbit/fastbit_element.cpp
@@ -124,7 +124,7 @@ void element::byte_reorder(uint8_t *dst, uint8_t *src, int srcSize, int dstSize)
 	}
 }
 
-void element::setName(uint32_t en, uint16_t id, int part)
+void element::set_name(uint32_t en, uint16_t id, int part)
 {
 	if (part == -1) { /* default */
 		sprintf(_name, "e%uid%hu", en, id);
@@ -209,7 +209,7 @@ el_var_size::el_var_size(int size, uint32_t en, uint16_t id, uint32_t buf_size)
 	_filled = 0;
 	_buffer = NULL;
 
-	setName(en, id);
+	set_name(en, id);
 	this->set_type();
 }
 
@@ -241,7 +241,7 @@ el_float::el_float(int size, uint32_t en, uint16_t id, uint32_t buf_size)
 	_filled = 0;
 	_buffer = NULL;
 
-	setName(en, id);
+	set_name(en, id);
 	this->set_type();
 
 	if (buf_size == 0) {
@@ -308,7 +308,7 @@ el_text::el_text(int size, uint32_t en, uint16_t id, uint32_t buf_size, struct f
 		_var_size = true;
 	}
 
-	setName(en, id);
+	set_name(en, id);
 	this->set_type();
 
 	if (buf_size == 0) {
@@ -436,7 +436,7 @@ el_ipv6::el_ipv6(int size, uint32_t en, uint16_t id, int part, uint32_t buf_size
 	_filled = 0;
 	_buffer = NULL;
 
-	setName(en, id, part);
+	set_name(en, id, part);
 	this->set_type();
 
 	if (buf_size == 0) {
@@ -474,7 +474,7 @@ el_blob::el_blob(int size, uint32_t en, uint16_t id, uint32_t buf_size):
 		_var_size = true;
 	}
 
-	setName(en, id);
+	set_name(en, id);
 	this->set_type();
 
 	if (buf_size == 0) {
@@ -596,7 +596,7 @@ el_uint::el_uint(int size, uint32_t en, uint16_t id, uint32_t buf_size)
 	_filled = 0;
 	_buffer = NULL;
 
-	setName(en, id);
+	set_name(en, id);
 	this->set_type();
 
 	if (buf_size == 0) {
@@ -727,7 +727,7 @@ el_sint::el_sint(int size, uint32_t en, uint16_t id, uint32_t buf_size)
 	_filled = 0;
 	_buffer = NULL;
 
-	setName(en, id);
+	set_name(en, id);
 	this->set_type();
 
 	if (buf_size == 0) {

--- a/plugins/storage/fastbit/fastbit_element.h
+++ b/plugins/storage/fastbit/fastbit_element.h
@@ -92,6 +92,8 @@ class element
 protected:
 	struct fastbit_config *_config;
 
+	uint32_t _en; /* Enterprise number */
+	uint16_t _id; /* Field ID */
 	int _size;
 	enum ibis::TYPE_T _type;
 
@@ -197,8 +199,9 @@ class el_var_size : public element
 {
 public:
 	void *data;
-	el_var_size(int size = 0, uint32_t en = 0, uint16_t id = 0, uint32_t buf_size = RESERVED_SPACE);
-	/* core methods */
+	el_var_size(int size = 0, uint32_t en = 0, uint16_t id = 0,
+			uint32_t buf_size = RESERVED_SPACE, struct fastbit_config *config = NULL);
+
 	/**
 	 * \brief Fill internal element value according to given data
 	 *
@@ -291,7 +294,8 @@ class el_ipv6 : public element
 {
 public:
 	uint64_t ipv6_value;
-	el_ipv6(int size = 1, uint32_t en = 0, uint16_t id = 0, int part = 0, uint32_t buf_size = RESERVED_SPACE);
+	el_ipv6(int size = 1, uint32_t en = 0, uint16_t id = 0, int part = 0,
+			uint32_t buf_size = RESERVED_SPACE, struct fastbit_config *config = NULL);
 
 	/**
 	 * \brief fill internal element value according to given data
@@ -313,7 +317,9 @@ protected:
 class el_blob : public element
 {
 public:
-	el_blob(int size = 1, uint32_t en = 0, uint16_t id = 0, uint32_t buf_size = RESERVED_SPACE);
+	el_blob(int size = 1, uint32_t en = 0, uint16_t id = 0,
+			uint32_t buf_size = RESERVED_SPACE, struct fastbit_config *config = NULL);
+
 	virtual uint16_t fill(uint8_t *data);
 	virtual ~el_blob();
 
@@ -353,8 +359,9 @@ typedef union uinteger_union
 class el_uint : public element
 {
 public:
-	el_uint(int size = 1, uint32_t en = 0, uint16_t id = 0, uint32_t buf_size = RESERVED_SPACE);
-	/* core methods */
+	el_uint(int size = 1, uint32_t en = 0, uint16_t id = 0,
+			uint32_t buf_size = RESERVED_SPACE, struct fastbit_config *config = NULL);
+
 	/**
 	 * \brief fill internal element value according to given data
 	 *
@@ -378,7 +385,8 @@ protected:
 class el_sint : public el_uint
 {
 public:
-	el_sint(int size = 1, uint32_t en = 0, uint16_t id = 0, uint32_t buf_size = RESERVED_SPACE);
+	el_sint(int size = 1, uint32_t en = 0, uint16_t id = 0,
+			uint32_t buf_size = RESERVED_SPACE, struct fastbit_config *config = NULL);
 
 protected:
 	int set_type();
@@ -409,7 +417,8 @@ protected:
 	int append(void *data);
 
 public:
-	el_unknown(int size = 0, uint32_t en = 0, uint16_t id = 0, int part = 0, uint32_t buf_size = 0);
+	el_unknown(int size = 0, uint32_t en = 0, uint16_t id = 0, int part = 0,
+			uint32_t buf_size = 0, struct fastbit_config *config = NULL);
 
 	/**
 	 * \brief fill internal element value according to given data

--- a/plugins/storage/fastbit/fastbit_element.h
+++ b/plugins/storage/fastbit/fastbit_element.h
@@ -94,9 +94,10 @@ protected:
 
 	int _size;
 	enum ibis::TYPE_T _type;
-	/* row name for this element
-	   combination of id and enterprise number
-	   exp: e0id16, e20id50.... */
+
+	/* Row name for this element, consisting of enterprise number and field id
+	 * Example: e0id16, e20id50, ...
+	 */
 	char _name[IE_NAME_LENGTH];
 
 	uint32_t _filled;  /* number of items are stored in buffer */
@@ -113,11 +114,11 @@ protected:
 	/**
 	 * \brief Set element name
 	 *
-	 * Element name is based on enterprise id and element id.
-	 * (e.g e0id5, e5id10 )
+	 * Element names are based on enterprise ID and element ID.
+	 * Examples: e0id5, e5id10, ...
 	 *
-	 * @param en Enterprise number of element
-	 * @param id ID of information element
+	 * @param en Enterprise ID
+	 * @param id Field ID
 	 * @param part Number of part (used for IPv6)
 	 */
 	void set_name(uint32_t en, uint16_t id, int part = -1);
@@ -128,7 +129,6 @@ protected:
 	 * This method simply copy data from src to dst
 	 * in oposite byte order.
 	 *
-	 *
 	 * @param dst pointer to destination memory where data should be writen (the memory MUST be preallocated)
 	 * @param src pointer to source data for byte reorder
 	 * @param size size of memory to copy & reorder from source data
@@ -137,14 +137,14 @@ protected:
 	void byte_reorder(uint8_t *dst, uint8_t *src, int size, int offset = 0);
 
 	/**
-	 * \brief allocate memory for buffer
+	 * \brief Allocate memory for buffer
 	 *
 	 * @param count Number of elements that the buffer should hold
 	 */
 	void allocate_buffer(uint32_t count);
 
 	/**
-	 * \brief free memory for buffer
+	 * \brief Free memory for buffer
 	 */
 	virtual void free_buffer();
 
@@ -158,9 +158,8 @@ protected:
 public:
 	virtual ~element() { free_buffer(); };
 
-	/* core methods */
 	/**
-	 * \brief fill internal element value according to given data
+	 * \brief Fill internal element value according to given data
 	 *
 	 * This method transforms data from ipfix record to internal
 	 * value usable by fastbit. Number of bytes to read is specified by _size
@@ -201,7 +200,7 @@ public:
 	el_var_size(int size = 0, uint32_t en = 0, uint16_t id = 0, uint32_t buf_size = RESERVED_SPACE);
 	/* core methods */
 	/**
-	 * \brief fill internal element value according to given data
+	 * \brief Fill internal element value according to given data
 	 *
 	 * This method transforms data from ipfix record to internal
 	 * value usable by fastbit. Number of bytes to read is specified by _size
@@ -227,10 +226,11 @@ class el_float : public element
 {
 public:
 	float_u float_value;
-	el_float(int size = 1, uint32_t en = 0, uint16_t id = 0, uint32_t buf_size = RESERVED_SPACE);
-	/* core methods */
+	el_float(int size = 1, uint32_t en = 0, uint16_t id = 0,
+			uint32_t buf_size = RESERVED_SPACE, struct fastbit_config *config = NULL);
+
 	/**
-	 * \brief fill internal element value according to given data
+	 * \brief Fill internal element value according to given data
 	 *
 	 * This method transforms data from ipfix record to internal
 	 * value usable by fastbit. Number of bytes to read is specified by _size
@@ -257,13 +257,14 @@ private:
 	uint32_t _sp_buffer_size;
 	uint32_t _sp_buffer_offset;
 public:
-	el_text(int size = 1, uint32_t en = 0, uint16_t id = 0, uint32_t buf_size = RESERVED_SPACE, struct fastbit_config *config = NULL);
+	el_text(int size = 1, uint32_t en = 0, uint16_t id = 0,
+			uint32_t buf_size = RESERVED_SPACE, struct fastbit_config *config = NULL);
+
 	virtual uint16_t fill(uint8_t *data);
 	virtual ~el_text();
 
 	/**
-	 * \brief Overloaded flush function to write the sp buffer
-	 *
+	 * \brief Overloaded flush function to write the sp buffer.
 	 * Calls parent funtion flush
 	 *
 	 * @param path to write the file to
@@ -369,7 +370,7 @@ public:
 
 protected:
 	uint_u uint_value;
-	uint16_t _real_size; /**< Element Size that was sent (can differ from storage _size) */
+	uint16_t _real_size; /* Element size that was sent in template; may differ from storage _size */
 
 	int set_type();
 };
@@ -410,7 +411,6 @@ protected:
 public:
 	el_unknown(int size = 0, uint32_t en = 0, uint16_t id = 0, int part = 0, uint32_t buf_size = 0);
 
-	/* core methods */
 	/**
 	 * \brief fill internal element value according to given data
 	 *

--- a/plugins/storage/fastbit/fastbit_element.h
+++ b/plugins/storage/fastbit/fastbit_element.h
@@ -120,7 +120,7 @@ protected:
 	 * @param id ID of information element
 	 * @param part Number of part (used for IPv6)
 	 */
-	void setName(uint32_t en, uint16_t id, int part = -1);
+	void set_name(uint32_t en, uint16_t id, int part = -1);
 
 	/**
 	 * \brief Copy data and change byte order

--- a/plugins/storage/fastbit/fastbit_table.cpp
+++ b/plugins/storage/fastbit/fastbit_table.cpp
@@ -225,7 +225,7 @@ int template_table::store(ipfix_data_set *data_set, std::string path, bool new_d
 		this->_new_dir = true;
 	}
 
-	/* Count how many records does data_set contain */
+	/* Count how many records data_set contains */
 	uint16_t data_size = (ntohs(data_set->header.length) - (sizeof(struct ipfix_set_header)));
 	uint16_t read_data = 0;
 	while (read_data < data_size) {
@@ -296,7 +296,7 @@ void template_table::flush(std::string path)
 int template_table::parse_template(struct ipfix_template *tmp, struct fastbit_config *config)
 {
 	int i;
-	uint32_t en = 0; /* enterprise number (0 = IANA elements) */
+	uint32_t en = 0; /* Enterprise number (0 = IANA elements) */
 	int en_offset = 0;
 	template_ie *field;
 	element *new_element;
@@ -315,7 +315,7 @@ int template_table::parse_template(struct ipfix_template *tmp, struct fastbit_co
 
 	_template_id = tmp->template_id;
 
-	/* Save the time of the template transmission */
+	/* Save template transmission time */
 	_first_transmission = tmp->first_transmission;
 
 	/* Find elements */
@@ -387,7 +387,7 @@ int template_table::parse_template(struct ipfix_template *tmp, struct fastbit_co
 		/* Check that this element does not already exist */
 		for (element *e : elements) {
 			if (strncmp(new_element->getName(), e->getName(), IE_NAME_LENGTH) == 0) {
-				/* This element already exists, replace it with unknown */
+				/* This element already exists; replace it with UNKNOWN type */
 				delete new_element;
 				new_element = new el_unknown(field->ie.length, en, field->ie.id & 0x7FFF, _buff_size);
 				break;

--- a/plugins/storage/fastbit/fastbit_table.cpp
+++ b/plugins/storage/fastbit/fastbit_table.cpp
@@ -337,43 +337,45 @@ int template_table::parse_template(struct ipfix_template *tmp, struct fastbit_co
 
 		switch(get_type_from_xml(config, en, field->ie.id & 0x7FFF)) {
 			case UINT:
-				new_element = new el_uint(field->ie.length, en, field->ie.id & 0x7FFF, _buff_size);
+				new_element = new el_uint(field->ie.length, en, field->ie.id & 0x7FFF, _buff_size, config);
 				break;
-			case IPv6:
-				/* IPv6 address are 128b in size, so we have to split them over two 64b rows
-				 * Adding p0 p1 sufixes to row name...
+			case IPV6:
+				/* IPv6 address are 128b in size, so we have to split them over two 64b rows. As such,
+				 * we add 'p0' and 'p1' sufixes to row name...
 				 */
+
 				/* Check size from template */
 				if (field->ie.length != 16) {
-					MSG_WARNING(msg_module, "Element e%iid%i has type 'IPv6' but size '%i'; skipping...", en, field->ie.id & 0x7FFF, field->ie.length);
+					MSG_WARNING(msg_module, "Element e%iid%i has type 'IPV6' but size '%i'; skipping...",
+							en, field->ie.id & 0x7FFF, field->ie.length);
 					new_element = new el_unknown(field->ie.length);
 					break;
 				}
 
-				new_element = new el_ipv6(sizeof(uint64_t), en, field->ie.id & 0x7FFF, 0, _buff_size);
+				new_element = new el_ipv6(sizeof(uint64_t), en, field->ie.id & 0x7FFF, 0, _buff_size, config);
 				elements.push_back(new_element);
 
-				new_element = new el_ipv6(sizeof(uint64_t), en, field->ie.id & 0x7FFF, 1, _buff_size);
+				new_element = new el_ipv6(sizeof(uint64_t), en, field->ie.id & 0x7FFF, 1, _buff_size, config);
 				break;
-			case INT: 
-				new_element = new el_sint(field->ie.length, en, field->ie.id & 0x7FFF, _buff_size);
+			case INT:
+				new_element = new el_sint(field->ie.length, en, field->ie.id & 0x7FFF, _buff_size, config);
 				break;
 			case FLOAT:
-				new_element = new el_float(field->ie.length, en, field->ie.id & 0x7FFF, _buff_size);
+				new_element = new el_float(field->ie.length, en, field->ie.id & 0x7FFF, _buff_size, config);
 				break;
 			case TEXT:
 				new_element = new el_text(field->ie.length, en, field->ie.id & 0x7FFF, _buff_size, config);
 				break;
 			case BLOB:
-				new_element = new el_blob(field->ie.length, en, field->ie.id & 0x7FFF, _buff_size);
+				new_element = new el_blob(field->ie.length, en, field->ie.id & 0x7FFF, _buff_size, config);
 				break;
 			case UNKNOWN:
 			default:
 				MSG_DEBUG(msg_module, "Received UNKNOWN element (size: %u)",field->ie.length);
 				if (field->ie.length < 9) {
-					new_element = new el_uint(field->ie.length, en, field->ie.id & 0x7FFF, _buff_size);
+					new_element = new el_uint(field->ie.length, en, field->ie.id & 0x7FFF, _buff_size, config);
 				} else {
-					new_element = new el_blob(field->ie.length, en, field->ie.id & 0x7FFF, _buff_size);
+					new_element = new el_blob(field->ie.length, en, field->ie.id & 0x7FFF, _buff_size, config);
 				}
 
 				break;
@@ -389,7 +391,7 @@ int template_table::parse_template(struct ipfix_template *tmp, struct fastbit_co
 			if (strncmp(new_element->getName(), e->getName(), IE_NAME_LENGTH) == 0) {
 				/* This element already exists; replace it with UNKNOWN type */
 				delete new_element;
-				new_element = new el_unknown(field->ie.length, en, field->ie.id & 0x7FFF, _buff_size);
+				new_element = new el_unknown(field->ie.length, en, field->ie.id & 0x7FFF, 0, _buff_size, config);
 				break;
 			}
 		}

--- a/plugins/storage/fastbit/ipfixcol-fastbit-output.dbk
+++ b/plugins/storage/fastbit/ipfixcol-fastbit-output.dbk
@@ -361,10 +361,18 @@
 			</varlistentry>
 			<varlistentry>
 				<term>
-					<command>createSpFiles</command>
+					<command>createSpFiles (no)</command>
 				</term>
 				<listitem>
 					<simpara>If enabled, the plugin will create .sp files for TEXT columns. These columns are typically created on-the-fly when performing queries on TEXT columns. However, under certain circumstances, like read-only file systems, these files may not be created on-the-fly. If this setting is set to "yes", the required .sp files are created as soon as the data is stored.</simpara>
+				</listitem>
+			</varlistentry>
+			<varlistentry>
+				<term>
+					<command>useTemplateFieldLengths (yes)</command>
+				</term>
+				<listitem>
+					<simpara>If enabled, the plugin will store the data in columns based on the field lengths indicated in IPFIX templates. Otherwise, the columns are based on field lengths implied by the IPFIX field specification in ipfix-elements.xml.</simpara>
 				</listitem>
 			</varlistentry>
 			<varlistentry>


### PR DESCRIPTION
This feature certainly needs some more testing, but we are providing it already to you for review. If no changes are made to `startup.xml`, the FastBit plugin should work just like before.