### PR TITLE
Typo fix in json plugin

### DIFF
--- a/plugins/storage/json/README.md
+++ b/plugins/storage/json/README.md
@@ -59,9 +59,9 @@ Here is an example of configuration in **startup.xml**:
 	<fileWriter>
 		<fileFormat>json</fileFormat>
 		<metadata>no</metadata>
-		<tcpFlags>formated</tcpFlags>
-		<timestamp>formated</timestamp>
-		<protocol>formated</protocol>
+		<tcpFlags>formatted</tcpFlags>
+		<timestamp>formatted</timestamp>
+		<protocol>formatted</protocol>
 		<ignoreUnknown>yes</ignoreUnknown>
 		<nonPrintableChar>yes</nonPrintableChar>
 
@@ -95,10 +95,10 @@ Here is an example of configuration in **startup.xml**:
 </destination>
 ```
 * **metadata** - Add record metadata to the output (yes/no) [default == no].
-* **tcpFlags** - Convert TCP flags to formated style of dots and letters (formated) or to a number (raw) [default == raw].
-* **timestamp** - Convert time to formated style (formated) or to a number (unix) [default == unix].
-* **protocol** - Convert protocol identification to formated style (formated) or to a number (raw) [default == formated].
-* **ignoreUnknown** - Skip elements with unknown semantics (yes/no). Data of unknown elements are formated as unsigned integer (1, 2, 4, 8 bytes length) or binary values. Names will have format 'eXXidYY' where XX is enterprise number and YY is element ID [default == yes].
+* **tcpFlags** - Convert TCP flags to formatted style of dots and letters (formatted) or to a number (raw) [default == raw].
+* **timestamp** - Convert time to formatted style (formatted) or to a number (unix) [default == unix].
+* **protocol** - Convert protocol identification to formatted style (formatted) or to a number (raw) [default == formatted].
+* **ignoreUnknown** - Skip elements with unknown semantics (yes/no). Data of unknown elements are formatted as unsigned integer (1, 2, 4, 8 bytes length) or binary values. Names will have format 'eXXidYY' where XX is enterprise number and YY is element ID [default == yes].
 * **nonPrintableChar** - Convert non-printable characters (control characters, tab, newline, etc.) from IPFIX fields with data type of a string. (yes/no) [default == yes].
 
 * **output** - Specifies JSON data processor. Multiple outputs are supported.

--- a/plugins/storage/json/ipfixcol-json-output.dbk
+++ b/plugins/storage/json/ipfixcol-json-output.dbk
@@ -66,9 +66,9 @@
 		<fileWriter>
 			<fileFormat>json</fileFormat>
 			<metadata>no</metadata>
-			<tcpFlags>formated</tcpFlags>
-			<timestamp>formated</timestamp>
-			<protocol>formated</protocol>
+			<tcpFlags>formatted</tcpFlags>
+			<timestamp>formatted</timestamp>
+			<protocol>formatted</protocol>
 			<ignoreUnknown>yes</ignoreUnknown>
 			<nonPrintableChar>yes</nonPrintableChar>
 
@@ -123,28 +123,28 @@
 				<varlistentry>
 					<term><command>tcpFlags</command></term>
 					<listitem>
-						<simpara>Convert TCP flags to formated style of dots and letters (formated) or to a number (raw) [default == raw].</simpara>
+						<simpara>Convert TCP flags to formatted style of dots and letters (formatted) or to a number (raw) [default == raw].</simpara>
 					</listitem>
 				</varlistentry>
 		
 				<varlistentry>
 					<term><command>timestamp</command></term>
 					<listitem>
-						<simpara>Convert time to formated style (formated) or to a number (unix) [default == unix].</simpara>
+						<simpara>Convert time to formatted style (formatted) or to a number (unix) [default == unix].</simpara>
 					</listitem>
 				</varlistentry>
 
 				<varlistentry>
 					<term><command>protocol</command></term>
 					<listitem>
-						<simpara>Convert protocol identification to formated style (formated) or to a number (raw) [default == formated].</simpara>
+						<simpara>Convert protocol identification to formatted style (formatted) or to a number (raw) [default == formatted].</simpara>
 					</listitem>
 				</varlistentry>
 
 				<varlistentry>
 					<term><command>ignoreUnknown</command></term>
 					<listitem>
-						<simpara>Skip elements with unknown semantics (yes/no). Data of unknown elements are formated as unsigned integer (1, 2, 4, 8 bytes length) or binary values. Names will have format 'eXXidYY' where XX is enterprise number and YY is element ID [default == yes].</simpara>
+						<simpara>Skip elements with unknown semantics (yes/no). Data of unknown elements are formatted as unsigned integer (1, 2, 4, 8 bytes length) or binary values. Names will have format 'eXXidYY' where XX is enterprise number and YY is element ID [default == yes].</simpara>
 					</listitem>
 				</varlistentry>
 

--- a/plugins/storage/json/json.cpp
+++ b/plugins/storage/json/json.cpp
@@ -78,11 +78,13 @@ void process_startup_xml(struct json_conf *conf, char *params)
 
 	/* Format of TCP flags */
 	std::string tcpFlags = ie.node().child_value("tcpFlags");
-	conf->tcpFlags = (strcasecmp(tcpFlags.c_str(), "formated") == 0);
+	conf->tcpFlags = (strcasecmp(tcpFlags.c_str(), "formated") == 0) ||
+                (strcasecmp(tcpFlags.c_str(), "formatted") == 0);
 
 	/* Format of timestamps */
 	std::string timestamp = ie.node().child_value("timestamp");
-	conf->timestamp = (strcasecmp(timestamp.c_str(), "formated") == 0);
+	conf->timestamp = (strcasecmp(timestamp.c_str(), "formated") == 0) ||
+                (strcasecmp(timestamp.c_str(), "formatted") == 0);
 
 	/* Format of protocols */
 	std::string protocol = ie.node().child_value("protocol");

--- a/plugins/storage/json/json.h
+++ b/plugins/storage/json/json.h
@@ -57,9 +57,9 @@ class Storage;
 struct json_conf {
 	bool metadata;
 	Storage *storage;
-	bool tcpFlags;       /**< TCP flags format - true(formated), false(RAW)  */
-	bool timestamp;      /**< timestamp format - true(formated), false(UNIX) */
-	bool protocol;       /**< protocol format  - true(RAW), false(formated)  */
+	bool tcpFlags;       /**< TCP flags format - true(formatted), false(RAW)  */
+	bool timestamp;      /**< timestamp format - true(formatted), false(UNIX) */
+	bool protocol;       /**< protocol format  - true(RAW), false(formatted)  */
 	bool ignoreUnknown;  /**< Ignore unknown elements                        */
 	bool whiteSpaces;    /**< Convert white spaces in strings (do not skip)  */
 };


### PR DESCRIPTION
s/formated/formatted/ in json storage plugin config and manpage. Backwards compatible with old spelling.