### PR TITLE
Minor typos in doc-comments and Doxygen warnings

### DIFF
--- a/base/src/input/tcp/tcp_input.c
+++ b/base/src/input/tcp/tcp_input.c
@@ -965,7 +965,7 @@ out:
  *
  * Compares L3 protocol, IP addresses and source port. ODID is not checked.
  *
- * \param[in] input_info structure to compare
+ * \param[in] info_list structure to compare
  * \param[in] address structure to compare
  * \return 0 if input_info matches the address, 1 otherwise
  */

--- a/base/src/input/tcp/tcp_input.c
+++ b/base/src/input/tcp/tcp_input.c
@@ -398,7 +398,7 @@ void remove_input_info(struct plugin_conf *conf, struct input_info_list *info, i
 }
 
 /**
- * \brief Funtion that listens for new connections
+ * \brief Function that listens for new connections
  *
  * Runs in a thread and adds new connections to plugin_conf->master set
  *

--- a/base/src/queues.c
+++ b/base/src/queues.c
@@ -120,7 +120,7 @@ struct ring_buffer* rbuffer_init(uint16_t size)
  *
  * @param[in] rbuffer Ring buffer.
  * @param[in] record IPFIX message structure to be added into the ring buffer.
- * @param[in] ref_count Initial refference count - number of reading threads.
+ * @param[in] ref_count Initial reference count - number of reading threads.
  * @return 0 on success, nonzero on error.
  */
 int rbuffer_write(struct ring_buffer* rbuffer, struct ipfix_message* record, uint16_t ref_count)

--- a/base/src/queues.c
+++ b/base/src/queues.c
@@ -136,7 +136,7 @@ int rbuffer_write(struct ring_buffer* rbuffer, struct ipfix_message* record, uin
 	}
 	/* it will be never more than ring buffer size, but just to be sure I'm checking it 
 	 * leave one position in buffer free, so that faster thread cannot read 
-	 * data yet not procees by slower one */
+	 * data yet not processed by slower one */
 	while (rbuffer->count + 1 >= rbuffer->size) {
 		if (pthread_cond_wait(&(rbuffer->cond), &(rbuffer->mutex)) != 0) {
 			MSG_ERROR(msg_module, "Condition wait failed (%s:%d)", __FILE__, __LINE__);

--- a/base/src/queues.h
+++ b/base/src/queues.h
@@ -82,14 +82,6 @@ struct ring_buffer {
  */
 struct ring_buffer* rbuffer_init(uint16_t size);
 
-/**
- * \brief Add new record into the ring buffer.
- *
- * @param[in] rbuffer Ring buffer.
- * @param[in] record IPFIX message structure to be added into the ring buffer.
- * @param[in] refcount Initial refference count - number of reading threads.
- * @return 0 on success, nonzero on error.
- */
 int rbuffer_write(struct ring_buffer* rbuffer, struct ipfix_message* record, uint16_t ref_count);
 
 /**

--- a/base/src/utils/libsiso/siso.h
+++ b/base/src/utils/libsiso/siso.h
@@ -118,7 +118,7 @@ extern "C" {
     
 	/**
 	 * \brief Check if a destination is connected
-	 * \paramf[in] conf
+	 * \param[in] conf
 	 * \return When the destination is NOT connected, returns 0. Otherwise
 	 *   returns non-zero value.
 	 */


### PR DESCRIPTION
There is also a major issue found while working on the last commit.  Maybe a larger patch to fix the duplication of doc-comments between header and `.c` is needed.